### PR TITLE
Add artifact metadata source to Forge Maven repo

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -210,6 +210,7 @@ public final class CompileConfiguration {
 
 				mavenArtifactRepository.metadataSources(sources -> {
 					sources.mavenPom();
+					sources.artifact();
 
 					try {
 						MavenArtifactRepository.MetadataSources.class.getDeclaredMethod("ignoreGradleMetadataRedirection")


### PR DESCRIPTION
MCP snapshot 20200514 does not have a `.pom` like 20201028, so `artifact()` must be added as a metadata source.

20200514 gives a 404:

https://files.minecraftforge.net/maven/de/oceanlabs/mcp/mcp_snapshot/20200514-1.16.3/mcp_snapshot-20200514-1.16.3.pom

20201028 is valid:

https://files.minecraftforge.net/maven/de/oceanlabs/mcp/mcp_snapshot/20201028-1.16.3/mcp_snapshot-20201028-1.16.3.pom

Adding `artifact()` allows 20200514 to be used like so:

```gradle
mappings group: "de.oceanlabs.mcp", name: "mcp_snapshot", version: "20200514-1.16.3", ext: "zip"
````

(`ext: "zip"` is required because otherwise Gradle looks for a `.jar`. This is equivalent to `<packaging>zip</packaging>` in `mcp_snapshot-20201028-1.16.3.pom`.)