### PR TITLE
Add the ability to name sourceSets in localMods

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -39,6 +39,9 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.gson.JsonObject;
+
+import net.fabricmc.loom.util.function.NamedSupplier;
+
 import org.cadixdev.lorenz.MappingSet;
 import org.cadixdev.mercury.Mercury;
 import org.gradle.api.Action;
@@ -167,6 +170,36 @@ public class LoomGradleExtension {
 					forgeLocalMods.add(() -> (SourceSet) sourceSet);
 				} else {
 					forgeLocalMods.add(() -> project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().findByName(String.valueOf(forgeLocalMods)));
+				}
+			}
+		}
+
+		public void named(String name, Object... sourceSets) {
+			for (Object sourceSet : sourceSets) {
+				if (sourceSet instanceof SourceSet) {
+					forgeLocalMods.add(new NamedSupplier<SourceSet>() {
+						@Override
+						public SourceSet get() {
+							return (SourceSet) sourceSet;
+						}
+
+						@Override
+						public String getName() {
+							return name;
+						}
+					});
+				} else {
+					forgeLocalMods.add(new NamedSupplier<SourceSet>() {
+						@Override
+						public SourceSet get() {
+							return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().findByName(String.valueOf(forgeLocalMods));
+						}
+
+						@Override
+						public String getName() {
+							return name;
+						}
+					});
 				}
 			}
 		}

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 
 import com.google.gson.JsonObject;
 
+import net.fabricmc.loom.configuration.mods.ModSourceConsumer;
 import net.fabricmc.loom.util.function.NamedSupplier;
 
 import org.cadixdev.lorenz.MappingSet;
@@ -164,6 +165,9 @@ public class LoomGradleExtension {
 	}
 
 	public class SourceSetConsumer {
+
+		private NamedDomainObjectContainer<ModSourceConsumer> sources = project.container(ModSourceConsumer.class, s -> new ModSourceConsumer(project, s, forgeLocalMods::add));
+
 		public void add(Object... sourceSets) {
 			for (Object sourceSet : sourceSets) {
 				if (sourceSet instanceof SourceSet) {
@@ -174,34 +178,8 @@ public class LoomGradleExtension {
 			}
 		}
 
-		public void named(String name, Object... sourceSets) {
-			for (Object sourceSet : sourceSets) {
-				if (sourceSet instanceof SourceSet) {
-					forgeLocalMods.add(new NamedSupplier<SourceSet>() {
-						@Override
-						public SourceSet get() {
-							return (SourceSet) sourceSet;
-						}
-
-						@Override
-						public String getName() {
-							return name;
-						}
-					});
-				} else {
-					forgeLocalMods.add(new NamedSupplier<SourceSet>() {
-						@Override
-						public SourceSet get() {
-							return project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().findByName(String.valueOf(forgeLocalMods));
-						}
-
-						@Override
-						public String getName() {
-							return name;
-						}
-					});
-				}
-			}
+		public NamedDomainObjectContainer<ModSourceConsumer> getSources() {
+			return this.sources;
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfig.java
@@ -45,6 +45,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
+import net.fabricmc.loom.util.function.NamedSupplier;
+
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.SourceSet;
@@ -144,7 +147,11 @@ public class RunConfig {
 
 			for (Supplier<SourceSet> sourceSetSupplier : extension.forgeLocalMods) {
 				SourceSet sourceSet = sourceSetSupplier.get();
-				String sourceSetName = sourceSet.getName() + "_" + UUID.randomUUID().toString().replace("-", "").substring(0, 7);
+				String sourceSetName;
+				if (sourceSetSupplier instanceof NamedSupplier && ((NamedSupplier<SourceSet>) sourceSetSupplier).getName() != null)
+					sourceSetName = ((NamedSupplier<SourceSet>) sourceSetSupplier).getName();
+				else
+					sourceSetName = sourceSet.getName() + "_" + UUID.randomUUID().toString().replace("-", "").substring(0, 7);;
 
 				Stream.concat(
 						Stream.of(sourceSet.getOutput().getResourcesDir().getAbsolutePath()),

--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModSourceConsumer.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModSourceConsumer.java
@@ -1,0 +1,51 @@
+package net.fabricmc.loom.configuration.mods;
+
+import net.fabricmc.loom.util.function.NamedSupplier;
+
+import org.gradle.api.Named;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class ModSourceConsumer implements Named {
+	private final Project project;
+	private final String name;
+	private final Consumer<Supplier<SourceSet>> consumer;
+
+	public ModSourceConsumer(Project project, String name, Consumer<Supplier<SourceSet>> consumer) {
+		this.project = project;
+		this.name = name;
+		this.consumer = consumer;
+	}
+
+	private Supplier<SourceSet> named(Supplier<SourceSet> supplier) {
+		return new NamedSupplier<SourceSet>() {
+			@Override
+			public SourceSet get() {
+				return supplier.get();
+			}
+
+			@Override
+			public String getName() {
+				return name;
+			}
+		};
+	}
+
+	public void add(Object... sourceSets) {
+		for (Object sourceSet : sourceSets) {
+			if (sourceSet instanceof SourceSet)
+				consumer.accept(named(() -> (SourceSet) sourceSet));
+			else
+				consumer.accept(named(() -> project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().findByName(String.valueOf(sourceSet))));
+		}
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/function/NamedSupplier.java
+++ b/src/main/java/net/fabricmc/loom/util/function/NamedSupplier.java
@@ -1,0 +1,11 @@
+package net.fabricmc.loom.util.function;
+
+import java.util.function.Supplier;
+
+@FunctionalInterface
+public interface NamedSupplier<T> extends Supplier<T> {
+
+	default String getName() {
+		return null;
+	}
+}


### PR DESCRIPTION
With the current design of forge loom, projects spanning multiple source sets cannot be loaded if they include a class from a non-main source set. (This is probably due to the way ExplodedDirectoryLocator works but I haven't checked)
This PR basically add something equivalent to ForgeGradle's mods:
```gradle
mods {
	modname {
		source sourceSets.main
		source sourceSets.api
	}
}
```
would become
```gradle
forgeLocalMods.clear()
localMods {
	modname {
		add sourceSets.main
		add sourceSets.api
	}
}
```
I haven't found a simple way to get rid of forgeLocalMods.clear() and keep backwards compatibility.