### PR TITLE
Name mappings, so I can work with multiple Minecraft versions at the same time

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MojangMappingsDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MojangMappingsDependency.java
@@ -135,7 +135,7 @@ public class MojangMappingsDependency extends AbstractModuleDependency implement
 			throw new UncheckedIOException(e);
 		}
 
-		Path mappingsFile = mappingsDir.resolve(String.format("mojmap-mappigns-%s.jar", getVersion()));
+		Path mappingsFile = mappingsDir.resolve(String.format("mojmap-mappings-%s.jar", getVersion()));
 		Path clientMappings = mappingsDir.resolve("client.map");
 		Path serverMappings = mappingsDir.resolve("server.map");
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MojangMappingsDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MojangMappingsDependency.java
@@ -128,12 +128,14 @@ public class MojangMappingsDependency extends AbstractModuleDependency implement
 	@Override
 	public Set<File> resolve() {
 		Path mappingsDir;
+
 		try {
 			mappingsDir = extension.getMappingsProvider().getMappedVersionedDir(String.format("mojang/%s.%s-%s", GROUP, MODULE, getVersion()));
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		}
-		Path mappingsFile = mappingsDir.resolve("mappings.tiny");
+
+		Path mappingsFile = mappingsDir.resolve(String.format("mappings-%s.tiny", getVersion()));
 		Path clientMappings = mappingsDir.resolve("client.map");
 		Path serverMappings = mappingsDir.resolve("server.map");
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MojangMappingsDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MojangMappingsDependency.java
@@ -135,7 +135,7 @@ public class MojangMappingsDependency extends AbstractModuleDependency implement
 			throw new UncheckedIOException(e);
 		}
 
-		Path mappingsFile = mappingsDir.resolve(String.format("mappings-%s.tiny", getVersion()));
+		Path mappingsFile = mappingsDir.resolve(String.format("mojmap-mappigns-%s.jar", getVersion()));
 		Path clientMappings = mappingsDir.resolve("client.map");
 		Path serverMappings = mappingsDir.resolve("server.map");
 


### PR DESCRIPTION
issue #25 
Now MappingsProvider will name the mojmap file `mappings-{mc version}.tiny-final.jar`
and I don't have to do *refresh dependencies* every time I change the version.