### PR TITLE
Avoid half-broken forge maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,15 @@ sourceSets {
 
 repositories {
 	mavenCentral()
+	maven { url "https://repo1.maven.org/maven2/"}
 	maven { url "https://maven.fabricmc.net/" }
 	maven { url "https://maven.architectury.dev/" }
-	maven { url "https://maven.minecraftforge.net/" }
+	maven {
+		url "https://maven.minecraftforge.net/"
+		content{
+			excludeGroupByRegex "org.eclipse.*"
+		}
+	}
 }
 
 configurations {


### PR DESCRIPTION
With this fix, we can avoid the half-broken forge maven.
No matter, how long will it take to fix that repo.