### PR TITLE
Allow specifying multiple accesstransformers

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -87,7 +87,7 @@ public class LoomGradleExtension {
 	public boolean remapMod = true;
 	public String customManifest = null;
 	public File accessWidener = null;
-	public File accessTransformer = null;
+	public Set<File> accessTransformers = new HashSet<>();
 	public Function<String, Object> intermediaryUrl = mcVer -> "https://maven.fabricmc.net/net/fabricmc/intermediary/" + mcVer + "/intermediary-" + mcVer + "-v2.jar";
 	public boolean shareCaches = false;
 	public List<String> mixinConfigs = new ArrayList<>(); // FORGE: Passed to Minecraft
@@ -282,7 +282,7 @@ public class LoomGradleExtension {
 	}
 
 	public void accessTransformer(Object file) {
-		this.accessTransformer = project.file(file);
+		this.accessTransformers.add(project.file(file));
 	}
 
 	public File getUserCache() {


### PR DESCRIPTION
Possible that this will break buildscripts that set the accessTransformer directly, but 0.9 is unstable anyways.

Signed-off-by: shedaniel <daniel@shedaniel.me>