### PR TITLE
Fix parameters and comments on Forge/with SRG merged mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@
 !/checkstyle.xml
 !/codenarc.groovy
 !/bootstrap
-!/forge-runtime

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,6 @@ if (!isSnapshot) {
 	version = baseVersion + "-PR." + System.getenv("PR_NUM") + "." + runNumber
 }
 
-version = '0.10.0-srgmappings.2'
-
 logger.lifecycle(":building plugin v${version}")
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ if (!isSnapshot) {
 	version = baseVersion + "-PR." + System.getenv("PR_NUM") + "." + runNumber
 }
 
+version = '0.10.0-srgmappings.2'
+
 logger.lifecycle(":building plugin v${version}")
 
 repositories {

--- a/src/main/java/net/fabricmc/loom/util/srg/SrgMerger.java
+++ b/src/main/java/net/fabricmc/loom/util/srg/SrgMerger.java
@@ -218,7 +218,7 @@ public final class SrgMerger {
 
 			MappingTree.MethodMapping method = CollectionUtil.find(
 					klass.getMethods(),
-					m -> m.getName("official").equals(def.getSrcName()) && m.getDesc("official").equals(def.getSrcDesc())
+					m -> m.getSrcName().equals(def.getName("official")) && m.getSrcDesc().equals(def.getDesc("official"))
 			).orElse(null);
 
 			if (method == null) {

--- a/src/main/java/net/fabricmc/loom/util/srg/SrgMerger.java
+++ b/src/main/java/net/fabricmc/loom/util/srg/SrgMerger.java
@@ -235,7 +235,7 @@ public final class SrgMerger {
 				String srgName = srgVar != null ? srgVar.getDstName(0) : null;
 				List<String> varNames = CollectionUtil.map(
 						output.getDstNamespaces(),
-						namespace -> "srg".equals(namespace) ? srgName : srgVar.getName(namespace)
+						namespace -> "srg".equals(namespace) ? srgName : var.getName(namespace)
 				);
 
 				flatOutput.visitMethodVar(obf, def.getName("official"), def.getDesc("official"), var.getLvtRowIndex(), var.getLvIndex(), var.getStartOpIdx(), var.getName("official"), varNames.toArray(new String[0]));


### PR DESCRIPTION
Note that parameters and comments won't be available for overridden JDK methods and constructors unless you're using `mergedv2` yarn due to FabricMC/fabric-loom#506.