### PR TITLE
Juuzify ArchitecturyLoomDecompiler

### DIFF
--- a/src/main/java/net/fabricmc/loom/api/decompilers/architectury/ArchitecturyLoomDecompiler.java
+++ b/src/main/java/net/fabricmc/loom/api/decompilers/architectury/ArchitecturyLoomDecompiler.java
@@ -24,12 +24,32 @@
 
 package net.fabricmc.loom.api.decompilers.architectury;
 
-import org.gradle.api.logging.Logger;
+import org.gradle.api.Project;
 
-import net.fabricmc.loom.task.GenerateSourcesTask;
+import net.fabricmc.loom.api.decompilers.LoomDecompiler;
 
+/**
+ * A decompiler definition. Differs from {@link LoomDecompiler} by allowing
+ * to use a project context for creating the decompiler, which lets you make
+ * configurable decompilers.
+ *
+ * <p>Note that JVM forking is not handled by this interface, and that is
+ * the responsibility of the decompiler implementation.
+ */
 public interface ArchitecturyLoomDecompiler {
+	/**
+	 * {@return the name of the decompiler}
+	 * It is used for naming the source generation task ({@code genSourcesWith[name]}).
+	 */
 	String name();
 
-	void decompile(Logger logger, GenerateSourcesTask.DecompileParams params);
+	/**
+	 * Creates a {@link LoomDecompiler} from a {@link Project} context.
+	 *
+	 * <p>The name of the created decompiler is not used.
+	 *
+	 * @param project the project context
+	 * @return the created decompiler
+	 */
+	LoomDecompiler create(Project project);
 }

--- a/src/main/java/net/fabricmc/loom/task/ArchitecturyGenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ArchitecturyGenerateSourcesTask.java
@@ -25,15 +25,20 @@
 package net.fabricmc.loom.task;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 
 import javax.inject.Inject;
 
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import net.fabricmc.loom.api.decompilers.DecompilationMetadata;
 import net.fabricmc.loom.api.decompilers.architectury.ArchitecturyLoomDecompiler;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.OperatingSystem;
@@ -47,11 +52,18 @@ public abstract class ArchitecturyGenerateSourcesTask extends AbstractLoomTask {
 	@Input
 	public abstract MapProperty<String, String> getOptions();
 
+	/**
+	 * Max memory for forked JVM in megabytes.
+	 */
+	@Input
+	public abstract Property<Long> getMaxMemory();
+
 	@Inject
 	public ArchitecturyGenerateSourcesTask(ArchitecturyLoomDecompiler decompiler) {
 		this.decompiler = decompiler;
 		getOutputs().upToDateWhen((o) -> false);
 		getOptions().finalizeValueOnRead();
+		getMaxMemory().convention(4096L).finalizeValueOnRead();
 	}
 
 	@TaskAction
@@ -60,20 +72,32 @@ public abstract class ArchitecturyGenerateSourcesTask extends AbstractLoomTask {
 			throw new UnsupportedOperationException("GenSources task requires a 64bit JVM to run due to the memory requirements.");
 		}
 
-		GenerateSourcesTask.DecompileParams params = getProject().getObjects().newInstance(GenerateSourcesTask.DecompileParams.class);
-
 		// TODO: Need a good way to not keep a duplicated code for this
-		params.getOptions().set(getOptions());
+		Path compiledJar = getInputJar().get().getAsFile().toPath();
+		Path runtimeJar = getExtension().getMappingsProvider().mappedProvider.getMappedJar().toPath();
+		Path sourcesDestination = GenerateSourcesTask.getMappedJarFileWithSuffix(getProject(), "-sources.jar").toPath();
+		Path linemapDestination = GenerateSourcesTask.getMappedJarFileWithSuffix(getProject(), "-sources.lmap").toPath();
+		DecompilationMetadata metadata = new DecompilationMetadata(
+				Runtime.getRuntime().availableProcessors(),
+				GenerateSourcesTask.getMappings(getProject(), getExtension()),
+				GenerateSourcesTask.DecompileAction.toPaths(getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES)),
+				getLogger()::info,
+				getOptions().get()
+		);
 
-		params.getInputJar().set(getInputJar());
-		params.getRuntimeJar().set(getExtension().getMappingsProvider().mappedProvider.getMappedJar());
-		params.getSourcesDestinationJar().set(GenerateSourcesTask.getMappedJarFileWithSuffix(getProject(), "-sources.jar"));
-		params.getLinemap().set(GenerateSourcesTask.getMappedJarFileWithSuffix(getProject(), "-sources.lmap"));
-		params.getLinemapJar().set(GenerateSourcesTask.getMappedJarFileWithSuffix(getProject(), "-linemapped.jar"));
-		params.getMappings().set(GenerateSourcesTask.getMappings(getProject(), getExtension()).toFile());
+		decompiler.create(getProject()).decompile(compiledJar, sourcesDestination, linemapDestination, metadata);
 
-		params.getClassPath().setFrom(getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES));
+		// Apply linemap
+		if (Files.exists(linemapDestination)) {
+			Path linemapJar = GenerateSourcesTask.getMappedJarFileWithSuffix(getProject(), "-linemapped.jar").toPath();
 
-		decompiler.decompile(getLogger(), params);
+			try {
+				GenerateSourcesTask.DecompileAction.remapLineNumbers(getLogger()::info, runtimeJar, linemapDestination, linemapJar);
+				Files.copy(linemapJar, runtimeJar, StandardCopyOption.REPLACE_EXISTING);
+				Files.delete(linemapJar);
+			} catch (Exception e) {
+				throw new RuntimeException("Could not remap line numbers", e);
+			}
+		}
 	}
 }

--- a/src/main/java/net/fabricmc/loom/task/ArchitecturyGenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/ArchitecturyGenerateSourcesTask.java
@@ -52,18 +52,11 @@ public abstract class ArchitecturyGenerateSourcesTask extends AbstractLoomTask {
 	@Input
 	public abstract MapProperty<String, String> getOptions();
 
-	/**
-	 * Max memory for forked JVM in megabytes.
-	 */
-	@Input
-	public abstract Property<Long> getMaxMemory();
-
 	@Inject
 	public ArchitecturyGenerateSourcesTask(ArchitecturyLoomDecompiler decompiler) {
 		this.decompiler = decompiler;
 		getOutputs().upToDateWhen((o) -> false);
 		getOptions().finalizeValueOnRead();
-		getMaxMemory().convention(4096L).finalizeValueOnRead();
 	}
 
 	@TaskAction

--- a/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateSourcesTask.java
@@ -43,6 +43,7 @@ import javax.inject.Inject;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -272,7 +273,7 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 			}
 		}
 
-		private void remapLineNumbers(IOStringConsumer logger, Path oldCompiledJar, Path linemap, Path linemappedJarDestination) throws IOException {
+		static void remapLineNumbers(IOStringConsumer logger, Path oldCompiledJar, Path linemap, Path linemappedJarDestination) throws IOException {
 			LineNumberRemapper remapper = new LineNumberRemapper();
 			remapper.readMappings(linemap.toFile());
 
@@ -283,7 +284,11 @@ public abstract class GenerateSourcesTask extends AbstractLoomTask {
 		}
 
 		private Collection<Path> getLibraries() {
-			return getParameters().getClassPath().getFiles().stream().map(File::toPath).collect(Collectors.toSet());
+			return toPaths(getParameters().getClassPath());
+		}
+
+		static Collection<Path> toPaths(FileCollection files) {
+			return files.getFiles().stream().map(File::toPath).collect(Collectors.toSet());
 		}
 	}
 


### PR DESCRIPTION
This API is much simpler to implement than the current `ArchitecturyLoomDecompiler` and does not expose unused implementation details like IPC and the linemap implementation. It is also clearer which jars should be used.

I also added line number remapping to the arch genSources task class.