### PR TITLE
Add forgeRuntimeLibrary configuration + some clean up

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -89,16 +89,24 @@ public final class CompileConfiguration {
 			extension.createLazyConfiguration(Constants.Configurations.FORGE_NAMED).configure(configuration -> configuration.setTransitive(false));
 			extension.createLazyConfiguration(Constants.Configurations.FORGE_EXTRA).configure(configuration -> configuration.setTransitive(false));
 			extension.createLazyConfiguration(Constants.Configurations.MCP_CONFIG).configure(configuration -> configuration.setTransitive(false));
+			extension.createLazyConfiguration(Constants.Configurations.FORGE_RUNTIME_LIBRARY);
 
 			extendsFrom(Constants.Configurations.MINECRAFT_DEPENDENCIES, Constants.Configurations.FORGE_DEPENDENCIES, project);
+
+			extendsFrom(Constants.Configurations.FORGE_RUNTIME_LIBRARY, Constants.Configurations.FORGE_DEPENDENCIES, project);
+			extendsFrom(Constants.Configurations.FORGE_RUNTIME_LIBRARY, Constants.Configurations.MINECRAFT_DEPENDENCIES, project);
+			extendsFrom(Constants.Configurations.FORGE_RUNTIME_LIBRARY, Constants.Configurations.FORGE_EXTRA, project);
+			extendsFrom(Constants.Configurations.FORGE_RUNTIME_LIBRARY, Constants.Configurations.MINECRAFT_NAMED, project);
+			extendsFrom(Constants.Configurations.FORGE_RUNTIME_LIBRARY, Constants.Configurations.FORGE_NAMED, project);
+			// Include any user-defined libraries on the runtime CP.
+			// (All the other superconfigurations are already on there.)
+			extendsFrom(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.FORGE_RUNTIME_LIBRARY, project);
 
 			extendsFrom(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.FORGE_NAMED, project);
 			extendsFrom(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.FORGE_NAMED, project);
 			extendsFrom(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.FORGE_NAMED, project);
 			extendsFrom(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.FORGE_NAMED, project);
-			extendsFrom(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.FORGE_EXTRA, project);
 			extendsFrom(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.FORGE_EXTRA, project);
-			extendsFrom(JavaPlugin.TEST_COMPILE_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.FORGE_EXTRA, project);
 			extendsFrom(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.FORGE_EXTRA, project);
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
@@ -299,21 +299,11 @@ public class ForgeUserdevProvider extends DependencyProvider {
 
 	private Set<File> runtimeClasspath() {
 		// Should we actually include the runtime classpath here? Forge doesn't seem to be using this property anyways
-		Set<File> mcLibs = DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.FORGE_DEPENDENCIES), true);
-		mcLibs.addAll(DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES), false));
-		mcLibs.addAll(DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.FORGE_EXTRA), false));
-		mcLibs.addAll(DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_NAMED), false));
-		mcLibs.addAll(DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.FORGE_NAMED), false));
-		return mcLibs;
+		return minecraftClasspath();
 	}
 
 	private Set<File> minecraftClasspath() {
-		Set<File> mcLibs = DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.FORGE_DEPENDENCIES), true);
-		mcLibs.addAll(DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES), false));
-		mcLibs.addAll(DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.FORGE_EXTRA), false));
-		mcLibs.addAll(DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_NAMED), false));
-		mcLibs.addAll(DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.FORGE_NAMED), false));
-		return mcLibs;
+		return DependencyDownloader.resolveFiles(getProject().getConfigurations().getByName(Constants.Configurations.FORGE_RUNTIME_LIBRARY), true);
 	}
 
 	public File getUserdevJar() {

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -79,9 +79,24 @@ public class Constants {
 		public static final String FORGE_USERDEV = "forgeUserdev";
 		public static final String FORGE_INSTALLER = "forgeInstaller";
 		public static final String FORGE_UNIVERSAL = "forgeUniversal";
+		/**
+		 * Forge's own dependencies. Not intended to be used by users,
+		 * {@link #FORGE_RUNTIME_LIBRARY forgeRuntimeLibrary} is for that instead.
+		 */
 		public static final String FORGE_DEPENDENCIES = "forgeDependencies";
 		public static final String FORGE_NAMED = "forgeNamed";
+		/**
+		 * "Extra" runtime dependencies on Forge. Contains the Minecraft resources
+		 * and {@linkplain Dependencies#FORGE_RUNTIME the Architectury Loom runtime}.
+		 */
 		public static final String FORGE_EXTRA = "forgeExtra";
+		/**
+		 * The configuration used to create the Forge runtime classpath file list.
+		 * Users can also directly add files to this config.
+		 *
+		 * @see net.fabricmc.loom.configuration.providers.forge.ForgeUserdevProvider
+		 */
+		public static final String FORGE_RUNTIME_LIBRARY = "forgeRuntimeLibrary";
 		public static final String MAPPING_CONSTANTS = "mappingsConstants";
 		public static final String UNPICK_CLASSPATH = "unpick";
 		/**

--- a/src/main/java/net/fabricmc/loom/util/DependencyDownloader.java
+++ b/src/main/java/net/fabricmc/loom/util/DependencyDownloader.java
@@ -81,6 +81,16 @@ public final class DependencyDownloader {
 		return files;
 	}
 
+	/**
+	 * Resolves a configuration and its superconfigurations.
+	 *
+	 * <p>Note that unlike resolving a {@linkplain Configuration#copyRecursive() recursive copy} of the configuration,
+	 * this method overrides the transitivity of all superconfigurations as well.
+	 *
+	 * @param configuration the configuration to resolve
+	 * @param transitive    true if transitive dependencies should be included, false otherwise
+	 * @return a mutable set containing the resolved files of the configuration
+	 */
 	public static Set<File> resolveFiles(Configuration configuration, boolean transitive) {
 		return resolve(configuration, transitive);
 	}


### PR DESCRIPTION
- `forgeRuntimeLibrary` is a user-facing configuration that can be used to add deps to the Forge runtime cp file.
  - NOT on the MC classpath like `forgeDependencies` (iirc this caused a bug for a user?)
- `forgeExtra` is no longer on the compile CP
  - It only contains the client extra jar as well as the Loom runtime, neither of which should be on the compile CP
  - **This is a breaking change if mods use it directly** (but that shouldn't be the case according to a quick github search)

A quick real-world test with Adorn showed no regressions in the generated CP file. The only difference was that using a single configuration removes an older version of the same library, which is probably wanted anyway.