### PR TITLE
Support for FG2-era Forge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,9 @@ dependencies {
 	implementation ('de.oceanlabs.mcp:mcinjector:3.8.0')
 	implementation ('com.opencsv:opencsv:5.4')
 
+	// Legacy Forge access transformers
+	implementation ('net.md-5:SpecialSource:1.10.0')
+
 	// Testing
 	testImplementation(gradleTestKit())
 	testImplementation('org.spockframework:spock-core:2.0-groovy-3.0') {
@@ -126,6 +129,7 @@ dependencies {
 	}
 	testImplementation 'io.javalin:javalin:3.13.11'
 	testImplementation 'net.fabricmc:fabric-installer:0.9.0'
+	runtimeOnly 'dev.architectury.architectury-pack200:dev.architectury.architectury-pack200.gradle.plugin:0.1.3'
 
 	compileOnly 'org.jetbrains:annotations:22.0.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -119,9 +119,6 @@ dependencies {
 	implementation ('de.oceanlabs.mcp:mcinjector:3.8.0')
 	implementation ('com.opencsv:opencsv:5.4')
 
-	// Legacy Forge access transformers
-	implementation ('net.md-5:SpecialSource:1.10.0')
-
 	// Testing
 	testImplementation(gradleTestKit())
 	testImplementation('org.spockframework:spock-core:2.0-groovy-3.0') {

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -143,7 +143,7 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 		return isForge() && getForgeUserdevProvider().isLegacyForge();
 	}
 
-	default boolean isModLauncher() {
+	default boolean isModernForge() {
 		return isForge() && !isLegacyForge();
 	}
 

--- a/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
+++ b/src/main/java/net/fabricmc/loom/LoomGradleExtension.java
@@ -139,6 +139,14 @@ public interface LoomGradleExtension extends LoomGradleExtensionAPI {
 		return isForge() && !getMcpConfigProvider().isOfficial();
 	}
 
+	default boolean isLegacyForge() {
+		return isForge() && getForgeUserdevProvider().isLegacyForge();
+	}
+
+	default boolean isModLauncher() {
+		return isForge() && !isLegacyForge();
+	}
+
 	boolean supportsInclude();
 
 	default SrgProvider getSrgProvider() {

--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -90,6 +90,20 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 				sources.ignoreGradleMetadataRedirection();
 			});
 		});
+		repositories.ivy(repo -> {
+			// Old MCP data does not have POMs
+			repo.setName("LegacyMCP");
+			repo.setUrl("https://maven.minecraftforge.net/");
+			repo.patternLayout(layout -> {
+				layout.artifact("[orgPath]/[artifact]/[revision]/[artifact]-[revision](-[classifier])(.[ext])");
+				// also check the zip so people do not have to explicitly specify the extension for older versions
+				layout.artifact("[orgPath]/[artifact]/[revision]/[artifact]-[revision](-[classifier]).zip");
+			});
+			repo.content(descriptor -> {
+				descriptor.includeGroup("de.oceanlabs.mcp");
+			});
+			repo.metadataSources(IvyArtifactRepository.MetadataSources::artifact);
+		});
 		repositories.mavenCentral();
 
 		repositories.ivy(repo -> {

--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -90,20 +90,6 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 				sources.ignoreGradleMetadataRedirection();
 			});
 		});
-		repositories.ivy(repo -> {
-			// Old MCP data does not have POMs
-			repo.setName("LegacyMCP");
-			repo.setUrl("https://maven.minecraftforge.net/");
-			repo.patternLayout(layout -> {
-				layout.artifact("[orgPath]/[artifact]/[revision]/[artifact]-[revision](-[classifier])(.[ext])");
-				// also check the zip so people do not have to explicitly specify the extension for older versions
-				layout.artifact("[orgPath]/[artifact]/[revision]/[artifact]-[revision](-[classifier]).zip");
-			});
-			repo.content(descriptor -> {
-				descriptor.includeGroup("de.oceanlabs.mcp");
-			});
-			repo.metadataSources(IvyArtifactRepository.MetadataSources::artifact);
-		});
 		repositories.mavenCentral();
 
 		repositories.ivy(repo -> {

--- a/src/main/java/net/fabricmc/loom/api/ForgeExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/ForgeExtensionAPI.java
@@ -33,6 +33,8 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.jetbrains.annotations.ApiStatus;
 
+import net.fabricmc.loom.configuration.providers.forge.fg2.Pack200Provider;
+
 /**
  * This is the forge extension api available exposed to build scripts.
  */
@@ -148,4 +150,6 @@ public interface ForgeExtensionAPI {
 	 * @see ForgeLocalMod
 	 */
 	NamedDomainObjectContainer<ForgeLocalMod> getLocalMods();
+
+	Property<Pack200Provider> getPack200Provider();
 }

--- a/src/main/java/net/fabricmc/loom/build/ModCompileRemapper.java
+++ b/src/main/java/net/fabricmc/loom/build/ModCompileRemapper.java
@@ -181,7 +181,7 @@ public class ModCompileRemapper {
 			}
 
 			if (forge) {
-				if (zipFile.getEntry("META-INF/mods.toml") != null) {
+				if (zipFile.getEntry("META-INF/mods.toml") != null || zipFile.getEntry("mcmod.info") != null) {
 					logger.info("Found Forge mod in " + config + ": {}", id);
 					return true;
 				}

--- a/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
@@ -101,7 +101,7 @@ public abstract class AnnotationProcessorInvoker<T extends Task> {
 		ConfigurationContainer configs = project.getConfigurations();
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 
-		if (!extension.ideSync() || extension.isLegacyForge()) {
+		if (!extension.ideSync()) {
 			for (Configuration processorConfig : apConfigurations) {
 				project.getLogger().info("Adding mixin to classpath of AP config: " + processorConfig.getName());
 				// Pass named MC classpath to mixin AP classpath

--- a/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
@@ -101,7 +101,7 @@ public abstract class AnnotationProcessorInvoker<T extends Task> {
 		ConfigurationContainer configs = project.getConfigurations();
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 
-		if (!extension.ideSync()) {
+		if (!extension.ideSync() || extension.isLegacyForge()) {
 			for (Configuration processorConfig : apConfigurations) {
 				project.getLogger().info("Adding mixin to classpath of AP config: " + processorConfig.getName());
 				// Pass named MC classpath to mixin AP classpath

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -198,9 +198,9 @@ public final class CompileConfiguration {
 			}
 
 			if (extension.isForge()) {
+				dependencyManager.addProvider(new ForgeUniversalProvider(project));
 				dependencyManager.addProvider(new McpConfigProvider(project));
 				dependencyManager.addProvider(new PatchProvider(project));
-				dependencyManager.addProvider(new ForgeUniversalProvider(project));
 			}
 
 			dependencyManager.addProvider(extension.isForge() ? new FieldMigratedMappingsProvider(project) : new MappingsProviderImpl(project));

--- a/src/main/java/net/fabricmc/loom/configuration/providers/LaunchProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/LaunchProvider.java
@@ -66,7 +66,7 @@ public class LaunchProvider extends DependencyProvider {
 				.property("client", "java.library.path", getExtension().getMinecraftProvider().nativesDir().getAbsolutePath())
 				.property("client", "org.lwjgl.librarypath", getExtension().getMinecraftProvider().nativesDir().getAbsolutePath());
 
-		if (!getExtension().isModLauncher()) {
+		if (!getExtension().isModernForge()) {
 			launchConfig
 					.argument("client", "--assetIndex")
 					.argument("client", getExtension().getMinecraftProvider().getVersionInfo().assetIndex().fabricId(getExtension().getMinecraftProvider().minecraftVersion()))
@@ -74,7 +74,7 @@ public class LaunchProvider extends DependencyProvider {
 					.argument("client", new File(getDirectories().getUserCache(), "assets").getAbsolutePath());
 		}
 
-		if (getExtension().isModLauncher()) {
+		if (getExtension().isModernForge()) {
 			launchConfig
 					// Should match YarnNamingService.PATH_TO_MAPPINGS in forge-runtime
 					.property("fabric.yarnWithSrg.path", getExtension().getMappingsProvider().tinyMappingsWithSrg.toAbsolutePath().toString())

--- a/src/main/java/net/fabricmc/loom/configuration/providers/LaunchProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/LaunchProvider.java
@@ -125,7 +125,7 @@ public class LaunchProvider extends DependencyProvider {
 		addDependency(Constants.Dependencies.TERMINAL_CONSOLE_APPENDER + Constants.Dependencies.Versions.TERMINAL_CONSOLE_APPENDER, Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES);
 		addDependency(Constants.Dependencies.JETBRAINS_ANNOTATIONS + Constants.Dependencies.Versions.JETBRAINS_ANNOTATIONS, JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
 
-		if (getExtension().isForge() && !getExtension().isLegacyForge()) {
+		if (getExtension().isModernForge()) {
 			addDependency(Constants.Dependencies.FORGE_RUNTIME + Constants.Dependencies.Versions.FORGE_RUNTIME, Constants.Configurations.FORGE_EXTRA);
 			addDependency(Constants.Dependencies.JAVAX_ANNOTATIONS + Constants.Dependencies.Versions.JAVAX_ANNOTATIONS, JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/FieldMigratedMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/FieldMigratedMappingsProvider.java
@@ -109,6 +109,13 @@ public class FieldMigratedMappingsProvider extends MappingsProviderImpl {
 	public void manipulateMappings(Path mappingsJar) throws IOException {
 		Stopwatch stopwatch = Stopwatch.createStarted();
 		LoomGradleExtension extension = getExtension();
+
+		if (extension.isLegacyForge()) {
+			// Legacy forge patches are in official namespace, so if the type of a field is changed by them, then that
+			// is effectively a new field and not traceable to any mapping. Therefore this does not apply to it.
+			return;
+		}
+
 		this.rawTinyMappings = tinyMappings;
 		this.rawTinyMappingsWithSrg = tinyMappingsWithSrg;
 		String mappingsJarName = mappingsJar.getFileName().toString();
@@ -116,7 +123,7 @@ public class FieldMigratedMappingsProvider extends MappingsProviderImpl {
 		if (getExtension().shouldGenerateSrgTiny()) {
 			if (Files.notExists(rawTinyMappingsWithSrg) || isRefreshDeps()) {
 				// Merge tiny mappings with srg
-				SrgMerger.mergeSrg(getProject().getLogger(), getExtension().getMappingsProvider()::getMojmapSrgFileIfPossible, getRawSrgFile(), rawTinyMappings, rawTinyMappingsWithSrg, true);
+				SrgMerger.mergeSrg(getProject().getLogger(), getExtension().getMappingsProvider()::getMojmapSrgFileIfPossible, getRawSrgFile(), rawTinyMappings, rawTinyMappingsWithSrg, true, false);
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
@@ -102,6 +102,7 @@ public class ForgeUserdevProvider extends DependencyProvider {
 			try (FileSystem fs = FileSystems.newFileSystem(new URI("jar:" + resolved.toURI()), ImmutableMap.of("create", false))) {
 				Path configEntry = fs.getPath("config.json");
 
+				// If we cannot find a modern config json, try the legacy/FG2-era one
 				if (!Files.exists(configEntry)) {
 					configEntry = fs.getPath("dev.json");
 				}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
@@ -50,6 +50,7 @@ import com.google.gson.JsonObject;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformOutputs;
@@ -132,6 +133,7 @@ public class ForgeUserdevProvider extends DependencyProvider {
 			addDependency(mcpDep, Constants.Configurations.MCP_CONFIG);
 			addDependency(mcpDep, Constants.Configurations.SRG);
 			addDependency(dependency.getDepString() + ":universal", Constants.Configurations.FORGE_UNIVERSAL);
+			addLegacyMCPRepo();
 		}
 
 		for (JsonElement lib : json.get("libraries").getAsJsonArray()) {
@@ -225,6 +227,23 @@ public class ForgeUserdevProvider extends DependencyProvider {
 			if (Constants.Forge.LAUNCH_TESTING.equals(config.getDefaultMainClass())) {
 				config.setDefaultMainClass(Constants.LegacyForge.LAUNCH_WRAPPER);
 			}
+		});
+	}
+
+	private void addLegacyMCPRepo() {
+		getProject().getRepositories().ivy(repo -> {
+			// Old MCP data does not have POMs
+			repo.setName("LegacyMCP");
+			repo.setUrl("https://maven.minecraftforge.net/");
+			repo.patternLayout(layout -> {
+				layout.artifact("[orgPath]/[artifact]/[revision]/[artifact]-[revision](-[classifier])(.[ext])");
+				// also check the zip so people do not have to explicitly specify the extension for older versions
+				layout.artifact("[orgPath]/[artifact]/[revision]/[artifact]-[revision](-[classifier]).zip");
+			});
+			repo.content(descriptor -> {
+				descriptor.includeGroup("de.oceanlabs.mcp");
+			});
+			repo.metadataSources(IvyArtifactRepository.MetadataSources::artifact);
 		});
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
@@ -164,8 +164,14 @@ public class ForgeUserdevProvider extends DependencyProvider {
 		// TODO: Should I copy the patches from here as well?
 		//       That'd require me to run the "MCP environment" fully up to merging.
 
-		JsonObject runs = isLegacyForge ? new JsonObject() : json.getAsJsonObject("runs");
+		if (!isLegacyForge) {
+			configureRuns(json.getAsJsonObject("runs"));
+		} else {
+			configureRunsForLegacyForge();
+		}
+	}
 
+	private void configureRuns(JsonObject runs) {
 		for (Map.Entry<String, JsonElement> entry : runs.entrySet()) {
 			LaunchProviderSettings launchSettings = getExtension().getLaunchConfigs().findByName(entry.getKey());
 			RunConfigSettings settings = getExtension().getRunConfigs().findByName(entry.getKey());
@@ -211,14 +217,14 @@ public class ForgeUserdevProvider extends DependencyProvider {
 				});
 			}
 		}
+	}
 
-		if (isLegacyForge) {
-			getExtension().getRunConfigs().configureEach(config -> {
-				if (Constants.Forge.LAUNCH_TESTING.equals(config.getDefaultMainClass())) {
-					config.setDefaultMainClass(Constants.LegacyForge.LAUNCH_WRAPPER);
-				}
-			});
-		}
+	private void configureRunsForLegacyForge() {
+		getExtension().getRunConfigs().configureEach(config -> {
+			if (Constants.Forge.LAUNCH_TESTING.equals(config.getDefaultMainClass())) {
+				config.setDefaultMainClass(Constants.LegacyForge.LAUNCH_WRAPPER);
+			}
+		});
 	}
 
 	public boolean isLegacyForge() {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
@@ -103,7 +103,7 @@ public class ForgeUserdevProvider extends DependencyProvider {
 				Path configEntry = fs.getPath("config.json");
 
 				// If we cannot find a modern config json, try the legacy/FG2-era one
-				if (!Files.exists(configEntry)) {
+				if (Files.notExists(configEntry)) {
 					configEntry = fs.getPath("dev.json");
 				}
 
@@ -117,7 +117,11 @@ public class ForgeUserdevProvider extends DependencyProvider {
 
 		isLegacyForge = !json.has("mcp");
 
-		if (isLegacyForge) {
+		if (!isLegacyForge) {
+			addDependency(json.get("mcp").getAsString(), Constants.Configurations.MCP_CONFIG);
+			addDependency(json.get("mcp").getAsString(), Constants.Configurations.SRG);
+			addDependency(json.get("universal").getAsString(), Constants.Configurations.FORGE_UNIVERSAL);
+		} else {
 			Map<String, String> mcpDep = Map.of(
 					"group", "de.oceanlabs.mcp",
 					"name", "mcp",
@@ -128,10 +132,6 @@ public class ForgeUserdevProvider extends DependencyProvider {
 			addDependency(mcpDep, Constants.Configurations.MCP_CONFIG);
 			addDependency(mcpDep, Constants.Configurations.SRG);
 			addDependency(dependency.getDepString() + ":universal", Constants.Configurations.FORGE_UNIVERSAL);
-		} else {
-			addDependency(json.get("mcp").getAsString(), Constants.Configurations.MCP_CONFIG);
-			addDependency(json.get("mcp").getAsString(), Constants.Configurations.SRG);
-			addDependency(json.get("universal").getAsString(), Constants.Configurations.FORGE_UNIVERSAL);
 		}
 
 		for (JsonElement lib : json.get("libraries").getAsJsonArray()) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/McpConfigProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/McpConfigProvider.java
@@ -64,6 +64,11 @@ public class McpConfigProvider extends DependencyProvider {
 
 	@Override
 	public void provide(DependencyInfo dependency, Consumer<Runnable> postPopulationScheduler) throws Exception {
+		if (getExtension().isLegacyForge()) {
+			official = false;
+			return;
+		}
+
 		init(dependency.getDependency().getVersion());
 
 		Path mcpZip = dependency.resolveFile().orElseThrow(() -> new RuntimeException("Could not resolve MCPConfig")).toPath();

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
@@ -186,7 +186,7 @@ public class MinecraftPatchedProvider extends DependencyProvider {
 		forgeMergedJar = getExtension().isForgeAndOfficial() ? null : new File(globalCache, "forge-official.jar");
 		minecraftMergedPatchedSrgAtJar = new File(projectDir, "merged-srg-at-patched.jar");
 		minecraftMergedPatchedJar = new File(projectDir, "merged-patched.jar");
-		minecraftClientExtra = new File(globalCache, "forge-client-extra.jar");
+		minecraftClientExtra = getExtension().isForgeAndOfficial() ? new File(globalCache, "forge-client-extra.jar") : null;
 
 		if (isRefreshDeps() || Stream.of(getGlobalCaches()).anyMatch(((Predicate<File>) File::exists).negate())
 						|| !isPatchedJarUpToDate(minecraftMergedPatchedJar)) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
@@ -223,14 +223,9 @@ public class MinecraftPatchedProvider extends DependencyProvider {
 				minecraftServerPatchedSrgJar,
 				minecraftMergedPatchedSrgJar,
 				minecraftClientExtra,
+				forgeMergedJar
 		};
-
-		if (forgeMergedJar != null) {
-			Arrays.copyOf(files, files.length + 1);
-			files[files.length - 1] = forgeMergedJar;
-		}
-
-		return files;
+		return Arrays.stream(files).filter(Objects::nonNull).toArray(File[]::new);
 	}
 
 	public void cleanProjectCache() {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/PatchProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/PatchProvider.java
@@ -24,7 +24,16 @@
 
 package net.fabricmc.loom.configuration.providers.forge;
 
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.FileSystem;
@@ -33,11 +42,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.function.Consumer;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
 
 import com.google.common.collect.ImmutableMap;
+import lzma.sdk.lzma.Decoder;
+import lzma.sdk.lzma.Encoder;
+import lzma.streams.LzmaInputStream;
+import lzma.streams.LzmaOutputStream;
+import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
 
 import net.fabricmc.loom.configuration.DependencyProvider;
+import net.fabricmc.loom.configuration.providers.forge.fg2.Pack200Provider;
 import net.fabricmc.loom.util.Constants;
 
 public class PatchProvider extends DependencyProvider {
@@ -56,11 +75,17 @@ public class PatchProvider extends DependencyProvider {
 		if (Files.notExists(clientPatches) || Files.notExists(serverPatches) || isRefreshDeps()) {
 			getProject().getLogger().info(":extracting forge patches");
 
-			Path installerJar = dependency.resolveFile().orElseThrow(() -> new RuntimeException("Could not resolve Forge installer")).toPath();
+			Path installerJar = getExtension().isLegacyForge()
+					? getExtension().getForgeUniversalProvider().getForge().toPath()
+					: dependency.resolveFile().orElseThrow(() -> new RuntimeException("Could not resolve Forge installer")).toPath();
 
 			try (FileSystem fs = FileSystems.newFileSystem(new URI("jar:" + installerJar.toUri()), ImmutableMap.of("create", false))) {
-				Files.copy(fs.getPath("data", "client.lzma"), clientPatches, StandardCopyOption.REPLACE_EXISTING);
-				Files.copy(fs.getPath("data", "server.lzma"), serverPatches, StandardCopyOption.REPLACE_EXISTING);
+				if (getExtension().isLegacyForge()) {
+					splitAndConvertLegacyPatches(fs.getPath("binpatches.pack.lzma"));
+				} else {
+					Files.copy(fs.getPath("data", "client.lzma"), clientPatches, StandardCopyOption.REPLACE_EXISTING);
+					Files.copy(fs.getPath("data", "server.lzma"), serverPatches, StandardCopyOption.REPLACE_EXISTING);
+				}
 			}
 		}
 	}
@@ -74,6 +99,73 @@ public class PatchProvider extends DependencyProvider {
 			Files.createDirectories(projectCacheFolder);
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
+		}
+	}
+
+	private void splitAndConvertLegacyPatches(Path joinedLegacyPatches) throws IOException {
+		try (JarInputStream in = new JarInputStream(new ByteArrayInputStream(unpack200Lzma(joinedLegacyPatches)));
+				OutputStream clientFileOut = Files.newOutputStream(clientPatches, CREATE, TRUNCATE_EXISTING);
+				LzmaOutputStream clientLzmaOut = new LzmaOutputStream(clientFileOut, new Encoder());
+				JarOutputStream clientJarOut = new JarOutputStream(clientLzmaOut);
+				OutputStream serverFileOut = Files.newOutputStream(serverPatches, CREATE, TRUNCATE_EXISTING);
+				LzmaOutputStream serverLzmaOut = new LzmaOutputStream(serverFileOut, new Encoder());
+				JarOutputStream serverJarOut = new JarOutputStream(serverLzmaOut);
+		) {
+			for (JarEntry entry; (entry = in.getNextJarEntry()) != null;) {
+				String name = entry.getName();
+
+				JarOutputStream out;
+
+				if (name.startsWith("binpatch/client/")) {
+					out = clientJarOut;
+				} else if (name.startsWith("binpatch/server/")) {
+					out = serverJarOut;
+				} else {
+					getProject().getLogger().warn("Unexpected file in Forge binpatches archive: " + name);
+					continue;
+				}
+
+				out.putNextEntry(new ZipEntry(name));
+
+				// Converting from legacy format to modern (v1) format
+				DataInputStream dataIn = new DataInputStream(in);
+				DataOutputStream dataOut = new DataOutputStream(out);
+				dataOut.writeByte(1); // version
+				dataIn.readUTF(); // unused patch name (presumably always the same as the obf class name)
+				dataOut.writeUTF(dataIn.readUTF().replace('.', '/')); // obf class name
+				dataOut.writeUTF(dataIn.readUTF().replace('.', '/')); // srg class name
+				IOUtils.copy(in, out); // remainder is unchanged
+
+				out.closeEntry();
+			}
+		}
+	}
+
+	private byte[] unpack200(InputStream in) throws IOException {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+		try (JarOutputStream jarOut = new JarOutputStream(bytes)) {
+			Pack200Provider provider = getExtension().getForge().getPack200Provider().getOrNull();
+
+			if (provider == null) {
+				throw new IllegalStateException("No provider for Pack200 has been found. Did you declare a provider?");
+			}
+
+			provider.unpack(in, jarOut);
+		}
+
+		return bytes.toByteArray();
+	}
+
+	private byte[] unpack200Lzma(InputStream in) throws IOException {
+		try (LzmaInputStream lzmaIn = new LzmaInputStream(in, new Decoder())) {
+			return unpack200(lzmaIn);
+		}
+	}
+
+	private byte[] unpack200Lzma(Path path) throws IOException {
+		try (InputStream in = Files.newInputStream(path)) {
+			return unpack200Lzma(in);
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/PatchProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/PatchProvider.java
@@ -75,16 +75,16 @@ public class PatchProvider extends DependencyProvider {
 		if (Files.notExists(clientPatches) || Files.notExists(serverPatches) || isRefreshDeps()) {
 			getProject().getLogger().info(":extracting forge patches");
 
-			Path installerJar = getExtension().isLegacyForge()
-					? getExtension().getForgeUniversalProvider().getForge().toPath()
-					: dependency.resolveFile().orElseThrow(() -> new RuntimeException("Could not resolve Forge installer")).toPath();
+			Path installerJar = getExtension().isModernForge()
+					? dependency.resolveFile().orElseThrow(() -> new RuntimeException("Could not resolve Forge installer")).toPath()
+					: getExtension().getForgeUniversalProvider().getForge().toPath();
 
 			try (FileSystem fs = FileSystems.newFileSystem(new URI("jar:" + installerJar.toUri()), ImmutableMap.of("create", false))) {
-				if (getExtension().isLegacyForge()) {
-					splitAndConvertLegacyPatches(fs.getPath("binpatches.pack.lzma"));
-				} else {
+				if (getExtension().isModernForge()) {
 					Files.copy(fs.getPath("data", "client.lzma"), clientPatches, StandardCopyOption.REPLACE_EXISTING);
 					Files.copy(fs.getPath("data", "server.lzma"), serverPatches, StandardCopyOption.REPLACE_EXISTING);
+				} else {
+					splitAndConvertLegacyPatches(fs.getPath("binpatches.pack.lzma"));
 				}
 			}
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/SrgProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/SrgProvider.java
@@ -94,6 +94,7 @@ public class SrgProvider extends DependencyProvider {
 				Path srgPath = fs.getPath("joined.srg");
 
 				if (Files.exists(srgPath)) {
+					// FG2-era MCP uses the older SRG format, convert it on the fly
 					try (Reader reader = Files.newBufferedReader(srgPath); Writer writer = Files.newBufferedWriter(srg)) {
 						new TSrgWriter(writer).write(new SrgReader(reader).read());
 					}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/fg2/MinecraftLegacyPatchedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/fg2/MinecraftLegacyPatchedProvider.java
@@ -1,0 +1,447 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2021 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.forge.fg2;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableMap;
+import net.md_5.specialsource.AccessChange;
+import net.md_5.specialsource.AccessMap;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import net.fabricmc.loom.configuration.providers.MinecraftProviderImpl;
+import net.fabricmc.loom.configuration.providers.forge.MinecraftPatchedProvider;
+import net.fabricmc.loom.configuration.providers.forge.PatchProvider;
+import net.fabricmc.loom.util.FileSystemUtil;
+import net.fabricmc.loom.util.ThreadingUtils;
+import net.fabricmc.loom.util.TinyRemapperHelper;
+import net.fabricmc.loom.util.ZipUtils;
+import net.fabricmc.mappingio.tree.MappingTree;
+import net.fabricmc.stitch.merge.JarMerger;
+
+public class MinecraftLegacyPatchedProvider extends MinecraftPatchedProvider {
+	// Step 1: Binary Patch (global)
+	private File minecraftClientPatchedJar;
+	private File minecraftServerPatchedJar;
+	// Step 2: Merge (global)
+	private File minecraftMergedPatchedJar;
+	// Step 4: Access Transform (global or project)
+	private File minecraftMergedPatchedAtJar;
+
+	private File forgeJar;
+
+	public MinecraftLegacyPatchedProvider(Project project) {
+		super(project);
+	}
+
+	@Override
+	public void initFiles() throws IOException {
+		filesDirty = false;
+		initAts();
+
+		File globalCache = getExtension().getForgeProvider().getGlobalCache();
+		File projectDir = usesProjectCache() ? getExtension().getForgeProvider().getProjectCache() : globalCache;
+		projectDir.mkdirs();
+
+		minecraftClientPatchedJar = new File(globalCache, "client-patched.jar");
+		minecraftServerPatchedJar = new File(globalCache, "server-patched.jar");
+		minecraftMergedPatchedJar = new File(globalCache, "merged-patched.jar");
+		minecraftMergedPatchedAtJar = new File(projectDir, "merged-at-patched.jar");
+
+		forgeJar = new File(globalCache, "forge.jar");
+
+		if (isRefreshDeps() || Stream.of(getGlobalCaches()).anyMatch(((Predicate<File>) File::exists).negate())
+				|| !isPatchedJarUpToDate(forgeJar) || !isPatchedJarUpToDate(minecraftMergedPatchedAtJar)) {
+			cleanAllCache();
+		} else if (atDirty || Stream.of(getProjectCache()).anyMatch(((Predicate<File>) File::exists).negate())) {
+			cleanProjectCache();
+		}
+	}
+
+	@Override
+	protected File[] getGlobalCaches() {
+		return new File[] {
+				minecraftClientPatchedJar,
+				minecraftServerPatchedJar,
+				minecraftMergedPatchedJar,
+				forgeJar,
+		};
+	}
+
+	@Override
+	protected File[] getProjectCache() {
+		return new File[] {
+				minecraftMergedPatchedAtJar,
+		};
+	}
+
+	@Override
+	public void provide(DependencyInfo dependency, Consumer<Runnable> postPopulationScheduler) throws Exception {
+		initFiles();
+
+		if (atDirty) {
+			getProject().getLogger().lifecycle(":found dirty access transformers");
+		}
+	}
+
+	@Override
+	public void finishProvide() throws Exception {
+		if (!forgeJar.exists()) {
+			filesDirty = true;
+			patchForge(getProject().getLogger());
+			applyLoomPatchVersion(forgeJar.toPath());
+		}
+
+		if (!minecraftClientPatchedJar.exists() || !minecraftServerPatchedJar.exists()) {
+			filesDirty = true;
+			patchJars(getProject().getLogger());
+		}
+
+		if (filesDirty || !minecraftMergedPatchedJar.exists()) {
+			filesDirty = true;
+			mergeJars(getProject().getLogger());
+		}
+
+		if (atDirty || filesDirty || !minecraftMergedPatchedAtJar.exists()) {
+			filesDirty = true;
+			accessTransformForge(getProject().getLogger());
+			applyLoomPatchVersion(minecraftMergedPatchedAtJar.toPath());
+		}
+	}
+
+	private void patchForge(Logger logger) throws Exception {
+		Stopwatch stopwatch = Stopwatch.createStarted();
+		logger.lifecycle(":patching forge");
+
+		Files.copy(getExtension().getForgeUniversalProvider().getForge().toPath(), forgeJar.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+		// For the development environment, we need to remove the binpatches, otherwise forge will try to re-apply them
+		try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(forgeJar, false)) {
+			Files.delete(fs.get().getPath("binpatches.pack.lzma"));
+		}
+
+		// Older versions of Forge rely on utility classes from log4j-core 2.0-beta9 but we'll upgrade the runtime to a
+		// release version (so we can use the TerminalConsoleAppender) where some of those classes have been moved from
+		// a `helpers` to a `utils` package.
+		// To allow Forge to work regardless, we'll re-package those helper classes into the forge jar.
+		Path log4jBeta9 = Arrays.stream(TinyRemapperHelper.getMinecraftDependencies(getProject()))
+				.filter(it -> it.getFileName().toString().equals("log4j-core-2.0-beta9.jar"))
+				.findAny()
+				.orElse(null);
+		if (log4jBeta9 != null) {
+			Predicate<Path> isHelper = path -> path.startsWith("/org/apache/logging/log4j/core/helpers");
+			walkFileSystems(log4jBeta9.toFile(), forgeJar, isHelper, this::copyReplacing);
+		}
+
+		logger.lifecycle(":patched forge in " + stopwatch.stop());
+	}
+
+	private void patchJars(Logger logger) throws Exception {
+		Stopwatch stopwatch = Stopwatch.createStarted();
+		logger.lifecycle(":patching jars");
+
+		MinecraftProviderImpl minecraftProvider = getExtension().getMinecraftProvider();
+		PatchProvider patchProvider = getExtension().getPatchProvider();
+		patchJars(minecraftProvider.minecraftServerJar, minecraftServerPatchedJar, patchProvider.serverPatches);
+		patchJars(minecraftProvider.minecraftClientJar, minecraftClientPatchedJar, patchProvider.clientPatches);
+
+		logger.lifecycle(":patched jars in " + stopwatch.stop());
+	}
+
+	@Override
+	protected void patchJars(File clean, File output, Path patches) throws Exception {
+		super.patchJars(clean, output, patches);
+
+		// Patching only preserves affected classes, everything else we need to copy manually
+		copyMissingClasses(clean, output);
+		copyNonClassFiles(clean, output);
+
+		// Workaround Forge patches apparently violating the JVM spec (see ParameterAnnotationsFixer for details)
+		modifyClasses(output, ParameterAnnotationsFixer::new);
+	}
+
+	private void mergeJars(Logger logger) throws Exception {
+		logger.info(":merging jars");
+		Stopwatch stopwatch = Stopwatch.createStarted();
+
+		try (JarMerger jarMerger = new JarMerger(minecraftClientPatchedJar, minecraftServerPatchedJar, minecraftMergedPatchedJar)) {
+			jarMerger.enableSyntheticParamsOffset();
+			jarMerger.merge();
+		}
+
+		// The JarMerger adds Sided annotations but so do the Forge patches. The latter doesn't require extra
+		// dependencies beyond Forge, so we'll keep those and remove the Fabric ones.
+		modifyClasses(minecraftMergedPatchedJar, FabricSideStripper::new);
+
+		logger.info(":merged jars in " + stopwatch);
+	}
+
+	private void accessTransformForge(Logger logger) throws Exception {
+		Stopwatch stopwatch = Stopwatch.createStarted();
+
+		logger.lifecycle(":access transforming minecraft");
+
+		MappingTree mappingTree = getExtension().getMappingsProvider().getMappingsWithSrg();
+
+		AccessMap accessMap = new LegacyAccessMap();
+
+		byte[] forgeAt = ZipUtils.unpack(forgeJar.toPath(), "forge_at.cfg");
+		accessMap.loadAccessTransformer(new BufferedReader(new InputStreamReader(new ByteArrayInputStream(forgeAt))));
+
+		for (File projectAt : projectAts) {
+			accessMap.loadAccessTransformer(projectAt);
+		}
+
+		Files.copy(minecraftMergedPatchedJar.toPath(), minecraftMergedPatchedAtJar.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+		modifyClasses(minecraftMergedPatchedAtJar, writer -> new AccessTransformingVisitor(accessMap, mappingTree, writer));
+
+		logger.lifecycle(":access transformed minecraft in " + stopwatch.stop());
+	}
+
+	private void modifyClasses(File jarFile, Function<ClassVisitor, ClassVisitor> func) throws Exception {
+		try (FileSystem fs = FileSystems.newFileSystem(new URI("jar:" + jarFile.toURI()), ImmutableMap.of("create", false))) {
+			ThreadingUtils.TaskCompleter completer = ThreadingUtils.taskCompleter();
+
+			for (Path file : (Iterable<? extends Path>) Files.walk(fs.getPath("/"))::iterator) {
+				if (!file.toString().endsWith(".class")) continue;
+
+				completer.add(() -> {
+					byte[] original = Files.readAllBytes(file);
+
+					ClassReader reader = new ClassReader(original);
+					ClassWriter writer = new ClassWriter(reader, 0);
+					reader.accept(func.apply(writer), 0);
+
+					byte[] modified = writer.toByteArray();
+
+					if (!Arrays.equals(original, modified)) {
+						Files.write(file, modified, StandardOpenOption.TRUNCATE_EXISTING);
+					}
+				});
+			}
+
+			completer.complete();
+		}
+	}
+
+	public File getMergedJar() {
+		return minecraftMergedPatchedAtJar;
+	}
+
+	public File getForgeMergedJar() {
+		return forgeJar;
+	}
+
+	/**
+	 * It seems that Forge patches produce class files which are in violation of the JVM spec. Specifically, the value
+	 * of Runtime[In]VisibleParameterAnnotation.num_parameters is by SE8 spec required to match the number of formal
+	 * parameters of the method (and may be ignored in favor of directly looking at the method arguments, which is
+	 * indeed what the OpenJDK 8 compiler does). Using a smaller value (possible if e.g. the last parameter has no
+	 * annotations) will cause the compiler to read past the end of the table, throwing an exception and therefore being
+	 * unable to read the class file.
+	 * <br>
+	 * This class visitor fixes that by ignoring the original num_parameters value, letting the MethodVisitor compute a
+	 * new value based on its signature. This will at first produce an invalid count when there are synthetic parameters
+	 * but later, during mergeJars, those will be properly offset (enableSyntheticParamsOffset).
+	 * <br>
+	 * SE8 JVM spec: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.18
+	 * Example method affected: RenderGlobal.ContainerLocalRenderInformation(RenderChunk, EnumFacing, int)
+	 */
+	private static class ParameterAnnotationsFixer extends ClassVisitor {
+		private ParameterAnnotationsFixer(ClassVisitor classVisitor) {
+			super(Opcodes.ASM9, classVisitor);
+		}
+
+		@Override
+		public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+			MethodVisitor methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+
+			// This issue has so far only been observed with constructors, so we can skip everything else
+			if (name.equals("<init>")) {
+				methodVisitor = new MethodFixer(methodVisitor);
+			}
+
+			return methodVisitor;
+		}
+
+		private static class MethodFixer extends MethodVisitor {
+			private MethodFixer(MethodVisitor methodVisitor) {
+				super(Opcodes.ASM9, methodVisitor);
+			}
+
+			@Override
+			public void visitAnnotableParameterCount(int parameterCount, boolean visible) {
+				// Not calling visitAnnotableParameterCount will cause it to compute its value from the method signature
+			}
+		}
+	}
+
+	private static class FabricSideStripper extends ClassVisitor {
+		private static final String SIDED_DESCRIPTOR = "Lnet/fabricmc/api/Environment;";
+
+		private FabricSideStripper(ClassVisitor classVisitor) {
+			super(Opcodes.ASM9, classVisitor);
+		}
+
+		@Override
+		public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+			if (descriptor.equals(SIDED_DESCRIPTOR)) {
+				return null;
+			}
+
+			return super.visitAnnotation(descriptor, visible);
+		}
+
+		@Override
+		public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+			return new FieldStripper(super.visitField(access, name, descriptor, signature, value));
+		}
+
+		@Override
+		public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+			return new MethodStripper(super.visitMethod(access, name, descriptor, signature, exceptions));
+		}
+
+		private static class FieldStripper extends FieldVisitor {
+			private FieldStripper(FieldVisitor fieldVisitor) {
+				super(Opcodes.ASM9, fieldVisitor);
+			}
+
+			@Override
+			public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+				if (descriptor.equals(SIDED_DESCRIPTOR)) {
+					return null;
+				}
+
+				return super.visitAnnotation(descriptor, visible);
+			}
+		}
+
+		private static class MethodStripper extends MethodVisitor {
+			private MethodStripper(MethodVisitor methodVisitor) {
+				super(Opcodes.ASM9, methodVisitor);
+			}
+
+			@Override
+			public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
+				if (descriptor.equals(SIDED_DESCRIPTOR)) {
+					return null;
+				}
+
+				return super.visitAnnotation(descriptor, visible);
+			}
+		}
+	}
+
+	private static class LegacyAccessMap extends AccessMap {
+		@Override
+		public void addAccessChange(String key, AccessChange accessChange) {
+			// Forge's AT separates fields/methods from their owner by a space but we require a slash
+			int spaceIdx = key.indexOf(' ');
+
+			if (spaceIdx != -1 && key.charAt(spaceIdx + 1) != '(') {
+				key = key.replaceFirst(" ", "/");
+			}
+
+			super.addAccessChange(key, accessChange);
+		}
+	}
+
+	private static class AccessTransformingVisitor extends ClassVisitor {
+		private final AccessMap accessMap;
+		private final MappingTree mappingTree;
+		private final int src;
+		private final int dst;
+
+		private MappingTree.ClassMapping classMapping;
+		private String mappedClassName;
+
+		private AccessTransformingVisitor(AccessMap accessMap, MappingTree mappingTree, ClassVisitor classVisitor) {
+			super(Opcodes.ASM9, classVisitor);
+			this.accessMap = accessMap;
+			this.mappingTree = mappingTree;
+			this.src = mappingTree.getNamespaceId("official");
+			this.dst = mappingTree.getNamespaceId("srg");
+		}
+
+		@Override
+		public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+			classMapping = mappingTree.getClass(name, src);
+			mappedClassName = classMapping != null ? classMapping.getName(dst) : name;
+			access = accessMap.applyClassAccess(mappedClassName, access);
+			super.visit(version, access, name, signature, superName, interfaces);
+		}
+
+		@Override
+		public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+			MappingTree.FieldMapping field = classMapping != null ? classMapping.getField(name, descriptor, src) : null;
+			String mappedName = field != null ? field.getName(dst) : name;
+			access = accessMap.applyFieldAccess(mappedClassName, mappedName, access);
+			return super.visitField(access, name, descriptor, signature, value);
+		}
+
+		@Override
+		public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+			MappingTree.MethodMapping method = classMapping != null ? classMapping.getMethod(name, desc, src) : null;
+			String mappedName = method != null ? method.getName(dst) : name;
+			String mappedDesc = method != null ? method.getDesc(dst) : mappingTree.mapDesc(desc, src, dst);
+			access = accessMap.applyMethodAccess(mappedClassName, mappedName, mappedDesc, access);
+			return super.visitMethod(access, name, desc, signature, exceptions);
+		}
+
+		@Override
+		public void visitInnerClass(String name, String outerName, String innerName, int access) {
+			MappingTree.ClassMapping classMapping = mappingTree.getClass(name, src);
+			access = accessMap.applyClassAccess(classMapping != null ? classMapping.getName(dst) : name, access);
+			super.visitInnerClass(name, outerName, innerName, access);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/fg2/Pack200Provider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/fg2/Pack200Provider.java
@@ -1,0 +1,8 @@
+package net.fabricmc.loom.configuration.providers.forge.fg2;
+
+import java.io.InputStream;
+import java.util.jar.JarOutputStream;
+
+public interface Pack200Provider {
+	void unpack(InputStream inputStream, JarOutputStream outputStream);
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
@@ -152,10 +152,10 @@ public class MappingsProviderImpl extends DependencyProvider implements Mappings
 		}
 
 		if (getExtension().isForge()) {
-			if (getExtension().isLegacyForge()) {
-				patchedProvider = new MinecraftLegacyPatchedProvider(getProject());
-			} else {
+			if (getExtension().isModernForge()) {
 				patchedProvider = new MinecraftPatchedProvider(getProject());
+			} else {
+				patchedProvider = new MinecraftLegacyPatchedProvider(getProject());
 			}
 
 			patchedProvider.provide(dependency, postPopulationScheduler);
@@ -588,14 +588,14 @@ public class MappingsProviderImpl extends DependencyProvider implements Mappings
 				hasRefreshed = true;
 
 				// Download and extract intermediary
-				if (getExtension().isLegacyForge()) {
-					generateDummyIntermediary(getProject().getLogger(), intermediaryTiny);
-				} else {
+				if (!getExtension().isLegacyForge()) {
 					String encodedMinecraftVersion = UrlEscapers.urlFragmentEscaper().escape(getMinecraftProvider().minecraftVersion());
 					String intermediaryArtifactUrl = getExtension().getIntermediaryUrl(encodedMinecraftVersion);
 					File intermediaryJar = getMinecraftProvider().file("intermediary-v2.jar");
 					DownloadUtil.downloadIfChanged(new URL(intermediaryArtifactUrl), intermediaryJar, getProject().getLogger());
 					extractMappings(intermediaryJar.toPath(), intermediaryTiny);
+				} else {
+					generateDummyIntermediary(getProject().getLogger(), intermediaryTiny);
 				}
 			}
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
@@ -202,7 +202,7 @@ public class MappingsProviderImpl extends DependencyProvider implements Mappings
 			}
 
 			if (Files.notExists(srgToNamedSrg) || isRefreshDeps()) {
-				SrgNamedWriter.writeTo(getProject().getLogger(), srgToNamedSrg, getMappingsWithSrg(), "srg", "named");
+				SrgNamedWriter.writeTo(srgToNamedSrg, getMappingsWithSrg(), "srg", "named", getExtension().isLegacyForge());
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
@@ -340,6 +340,7 @@ public class MappingsProviderImpl extends DependencyProvider implements Mappings
 			getProject().getDependencies().add(provider.getTargetConfig(), "de.oceanlabs.mcp:mcp_config:" + getMinecraftProvider().minecraftVersion());
 			Configuration configuration = getProject().getConfigurations().getByName(provider.getTargetConfig());
 			provider.provide(DependencyInfo.create(getProject(), configuration.getDependencies().iterator().next(), configuration), postPopulationScheduler);
+			getExtension().getDependencyManager().addProvider(provider);
 		}
 
 		Path srgPath = getRawSrgFile();

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMappedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/MinecraftMappedProvider.java
@@ -266,7 +266,17 @@ public class MinecraftMappedProvider extends DependencyProvider {
 	}
 
 	public void remap(TinyRemapper remapper, Mutable<MemoryMappingTree> mappings, List<TinyRemapper.ApplyVisitorProvider> postApply, Info vanilla, @Nullable Info forge, String fromM) throws IOException {
-		Set<String> classNames = getExtension().isForge() ? InnerClassRemapper.readClassNames(vanilla.input) : null;
+		Set<String> classNames;
+
+		if (getExtension().isForge()) {
+			classNames = InnerClassRemapper.readClassNames(vanilla.input);
+
+			if (forge != null) {
+				classNames.addAll(InnerClassRemapper.readClassNames(forge.input));
+			}
+		} else {
+			classNames = null;
+		}
 
 		for (String toM : getExtension().isForge() ? Arrays.asList(MappingsNamespace.INTERMEDIARY.toString(), MappingsNamespace.SRG.toString(), MappingsNamespace.NAMED.toString()) : Arrays.asList(MappingsNamespace.INTERMEDIARY.toString(), MappingsNamespace.NAMED.toString())) {
 			Path output = MappingsNamespace.NAMED.toString().equals(toM) ? vanilla.outputMapped : MappingsNamespace.SRG.toString().equals(toM) ? vanilla.outputSrg : vanilla.outputIntermediary;

--- a/src/main/java/net/fabricmc/loom/extension/ForgeExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/ForgeExtensionImpl.java
@@ -42,6 +42,7 @@ import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.ForgeExtensionAPI;
 import net.fabricmc.loom.api.ForgeLocalMod;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
+import net.fabricmc.loom.configuration.providers.forge.fg2.Pack200Provider;
 
 public class ForgeExtensionImpl implements ForgeExtensionAPI {
 	private final LoomGradleExtension extension;
@@ -52,6 +53,7 @@ public class ForgeExtensionImpl implements ForgeExtensionAPI {
 	private final Property<Boolean> useCustomMixin;
 	private final List<String> dataGenMods = new ArrayList<>(); // not a property because it has custom adding logic
 	private final NamedDomainObjectContainer<ForgeLocalMod> localMods;
+	private final Property<Pack200Provider> pack200Provider;
 
 	@Inject
 	public ForgeExtensionImpl(Project project, LoomGradleExtension extension) {
@@ -63,6 +65,7 @@ public class ForgeExtensionImpl implements ForgeExtensionAPI {
 		useCustomMixin = project.getObjects().property(Boolean.class).convention(true);
 		localMods = project.container(ForgeLocalMod.class,
 				baseName -> new ForgeLocalMod(project, baseName, new ArrayList<>()));
+		pack200Provider = project.getObjects().property(Pack200Provider.class);
 
 		// Create default mod from main source set
 		localMods(mod -> mod.create("main").add("main"));
@@ -132,5 +135,10 @@ public class ForgeExtensionImpl implements ForgeExtensionAPI {
 	@Override
 	public NamedDomainObjectContainer<ForgeLocalMod> getLocalMods() {
 		return localMods;
+	}
+
+	@Override
+	public Property<Pack200Provider> getPack200Provider() {
+		return pack200Provider;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -177,4 +177,10 @@ public class Constants {
 		private Forge() {
 		}
 	}
+
+	public static final class LegacyForge {
+		public static final String LAUNCH_WRAPPER = "net.minecraft.launchwrapper.Launch";
+		public static final String FML_TWEAKER = "net.minecraftforge.fml.common.launcher.FMLTweaker";
+		public static final String FML_SERVER_TWEAKER = "net.minecraftforge.fml.common.launcher.FMLServerTweaker";
+	}
 }

--- a/src/main/java/net/fabricmc/loom/util/LoggerFilter.java
+++ b/src/main/java/net/fabricmc/loom/util/LoggerFilter.java
@@ -26,6 +26,7 @@ package net.fabricmc.loom.util;
 
 import java.io.PrintStream;
 
+import org.apache.commons.io.output.NullOutputStream;
 import org.jetbrains.annotations.NotNull;
 
 public class LoggerFilter {
@@ -45,5 +46,32 @@ public class LoggerFilter {
 		} catch (SecurityException ignored) {
 			// Failed to replace logger filter, just ignore
 		}
+	}
+
+	public static <T extends Throwable> void withSystemOutAndErrSuppressed(CheckedRunnable<T> block) throws T {
+		PrintStream previousOut = System.out;
+		PrintStream previousErr = System.err;
+
+		try {
+			System.setOut(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM));
+			System.setErr(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM));
+		} catch (SecurityException ignored) {
+			// Failed to replace logger, just ignore
+		}
+
+		try {
+			block.run();
+		} finally {
+			try {
+				System.setOut(previousOut);
+				System.setErr(previousErr);
+			} catch (SecurityException ignored) {
+				// Failed to replace logger, just ignore
+			}
+		}
+	}
+
+	public interface CheckedRunnable<T extends Throwable> {
+		void run() throws T;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/util/legacyforge/CoreModManagerTransformer.java
+++ b/src/main/java/net/fabricmc/loom/util/legacyforge/CoreModManagerTransformer.java
@@ -1,0 +1,238 @@
+package net.fabricmc.loom.util.legacyforge;
+
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.BIPUSH;
+import static org.objectweb.asm.Opcodes.CHECKCAST;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.ICONST_0;
+import static org.objectweb.asm.Opcodes.IFEQ;
+import static org.objectweb.asm.Opcodes.IFNONNULL;
+import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.NEW;
+import static org.objectweb.asm.Opcodes.POP;
+import static org.objectweb.asm.Opcodes.RETURN;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Transforms Forge's CoreModManager class to search the classpath for coremods.
+ * For motivation, see comments at usage site.
+ */
+public class CoreModManagerTransformer extends ClassVisitor {
+	private static final String CLASS = "net/minecraftforge/fml/relauncher/CoreModManager";
+	public static final String FILE = CLASS + ".class";
+
+	private static final String TARGET_METHOD = "discoverCoreMods";
+	private static final String OUR_METHOD_NAME = "loom$injectCoremodsFromClasspath";
+	private static final String OUR_METHOD_DESCRIPTOR = "(Lnet/minecraft/launchwrapper/LaunchClassLoader;)V";
+
+	public CoreModManagerTransformer(ClassVisitor classVisitor) {
+		super(Opcodes.ASM9, classVisitor);
+	}
+
+	@Override
+	public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+		MethodVisitor methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+
+		// We inject a call to our method, which will discover and load coremods from the classpath, at the very start of the
+		// regular discovery method.
+		if (name.equals(TARGET_METHOD)) {
+			methodVisitor = new InjectCallAtHead(methodVisitor);
+		}
+
+		return methodVisitor;
+	}
+
+	@Override
+	public void visitEnd() {
+		// We add the following method, which will find all coremods on the classpath, and load them.
+		//
+		//     private static void loom$injectCoremodsFromClasspath(LaunchClassLoader classLoader) throws Exception {
+		//         Enumeration<URL> urls = classLoader.getResources("META-INF/MANIFEST.MF");
+		//         while (urls.hasMoreElements()) {
+		//             URL url = urls.nextElement();
+		//             InputStream stream = url.openStream();
+		//             Manifest manifest = new Manifest(stream);
+		//             stream.close();
+		//             String coreModClass = manifest.getMainAttributes().getValue("FMLCorePlugin");
+		//             if (coreModClass == null) continue;
+		//             File file;
+		//             if ("jar".equals(url.getProtocol())) {
+		//                 file = new File(new URL(url.getPath()).toURI());
+		//             } else if ("file".equals(url.getProtocol())) {
+		//                 file = new File(url.toURI()).getParentFile().getParentFile();
+		//             } else {
+		//                 continue;
+		//             }
+		//             loadCoreMod(classLoader, coreModClass, file);
+		//         }
+		//     }
+		//
+		// Converted to ASM via the "ASM Bytecode Viewer" IntelliJ plugin:
+		{
+			MethodVisitor methodVisitor = super.visitMethod(ACC_PRIVATE | ACC_STATIC, OUR_METHOD_NAME, OUR_METHOD_DESCRIPTOR, null, null);
+			methodVisitor.visitCode();
+			Label label0 = new Label();
+			methodVisitor.visitLabel(label0);
+			methodVisitor.visitLineNumber(25, label0);
+			methodVisitor.visitVarInsn(ALOAD, 0);
+			methodVisitor.visitLdcInsn("META-INF/MANIFEST.MF");
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "net/minecraft/launchwrapper/LaunchClassLoader", "getResources", "(Ljava/lang/String;)Ljava/util/Enumeration;", false);
+			methodVisitor.visitVarInsn(ASTORE, 1);
+			Label label1 = new Label();
+			methodVisitor.visitLabel(label1);
+			methodVisitor.visitLineNumber(26, label1);
+			methodVisitor.visitFrame(Opcodes.F_APPEND, 1, new Object[]{"java/util/Enumeration"}, 0, null);
+			methodVisitor.visitVarInsn(ALOAD, 1);
+			methodVisitor.visitMethodInsn(INVOKEINTERFACE, "java/util/Enumeration", "hasMoreElements", "()Z", true);
+			Label label2 = new Label();
+			methodVisitor.visitJumpInsn(IFEQ, label2);
+			Label label3 = new Label();
+			methodVisitor.visitLabel(label3);
+			methodVisitor.visitLineNumber(27, label3);
+			methodVisitor.visitVarInsn(ALOAD, 1);
+			methodVisitor.visitMethodInsn(INVOKEINTERFACE, "java/util/Enumeration", "nextElement", "()Ljava/lang/Object;", true);
+			methodVisitor.visitTypeInsn(CHECKCAST, "java/net/URL");
+			methodVisitor.visitVarInsn(ASTORE, 2);
+			Label label4 = new Label();
+			methodVisitor.visitLabel(label4);
+			methodVisitor.visitLineNumber(28, label4);
+			methodVisitor.visitVarInsn(ALOAD, 2);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/net/URL", "openStream", "()Ljava/io/InputStream;", false);
+			methodVisitor.visitVarInsn(ASTORE, 3);
+			Label label5 = new Label();
+			methodVisitor.visitLabel(label5);
+			methodVisitor.visitLineNumber(29, label5);
+			methodVisitor.visitTypeInsn(NEW, "java/util/jar/Manifest");
+			methodVisitor.visitInsn(DUP);
+			methodVisitor.visitVarInsn(ALOAD, 3);
+			methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/util/jar/Manifest", "<init>", "(Ljava/io/InputStream;)V", false);
+			methodVisitor.visitVarInsn(ASTORE, 4);
+			Label label6 = new Label();
+			methodVisitor.visitLabel(label6);
+			methodVisitor.visitLineNumber(30, label6);
+			methodVisitor.visitVarInsn(ALOAD, 3);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/io/InputStream", "close", "()V", false);
+			Label label7 = new Label();
+			methodVisitor.visitLabel(label7);
+			methodVisitor.visitLineNumber(31, label7);
+			methodVisitor.visitVarInsn(ALOAD, 4);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/util/jar/Manifest", "getMainAttributes", "()Ljava/util/jar/Attributes;", false);
+			methodVisitor.visitLdcInsn("FMLCorePlugin");
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/util/jar/Attributes", "getValue", "(Ljava/lang/String;)Ljava/lang/String;", false);
+			methodVisitor.visitVarInsn(ASTORE, 5);
+			Label label8 = new Label();
+			methodVisitor.visitLabel(label8);
+			methodVisitor.visitLineNumber(32, label8);
+			methodVisitor.visitVarInsn(ALOAD, 5);
+			Label label9 = new Label();
+			methodVisitor.visitJumpInsn(IFNONNULL, label9);
+			methodVisitor.visitJumpInsn(GOTO, label1);
+			methodVisitor.visitLabel(label9);
+			methodVisitor.visitLineNumber(34, label9);
+			methodVisitor.visitFrame(Opcodes.F_FULL, 6, new Object[]{"net/minecraft/launchwrapper/LaunchClassLoader", "java/util/Enumeration", "java/net/URL", "java/io/InputStream", "java/util/jar/Manifest", "java/lang/String"}, 0, new Object[]{});
+			methodVisitor.visitLdcInsn("jar");
+			methodVisitor.visitVarInsn(ALOAD, 2);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/net/URL", "getProtocol", "()Ljava/lang/String;", false);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z", false);
+			Label label10 = new Label();
+			methodVisitor.visitJumpInsn(IFEQ, label10);
+			Label label11 = new Label();
+			methodVisitor.visitLabel(label11);
+			methodVisitor.visitLineNumber(35, label11);
+			methodVisitor.visitTypeInsn(NEW, "java/io/File");
+			methodVisitor.visitInsn(DUP);
+			methodVisitor.visitTypeInsn(NEW, "java/net/URL");
+			methodVisitor.visitInsn(DUP);
+			methodVisitor.visitVarInsn(ALOAD, 2);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/net/URL", "getPath", "()Ljava/lang/String;", false);
+			methodVisitor.visitInsn(ICONST_0);
+			methodVisitor.visitVarInsn(ALOAD, 2);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/net/URL", "getPath", "()Ljava/lang/String;", false);
+			methodVisitor.visitIntInsn(BIPUSH, 33);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "lastIndexOf", "(I)I", false);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "substring", "(II)Ljava/lang/String;", false);
+			methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/net/URL", "<init>", "(Ljava/lang/String;)V", false);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/net/URL", "toURI", "()Ljava/net/URI;", false);
+			methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/io/File", "<init>", "(Ljava/net/URI;)V", false);
+			methodVisitor.visitVarInsn(ASTORE, 6);
+			Label label12 = new Label();
+			methodVisitor.visitLabel(label12);
+			Label label13 = new Label();
+			methodVisitor.visitJumpInsn(GOTO, label13);
+			methodVisitor.visitLabel(label10);
+			methodVisitor.visitLineNumber(36, label10);
+			methodVisitor.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+			methodVisitor.visitLdcInsn("file");
+			methodVisitor.visitVarInsn(ALOAD, 2);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/net/URL", "getProtocol", "()Ljava/lang/String;", false);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "equals", "(Ljava/lang/Object;)Z", false);
+			methodVisitor.visitJumpInsn(IFEQ, label1);
+			Label label14 = new Label();
+			methodVisitor.visitLabel(label14);
+			methodVisitor.visitLineNumber(37, label14);
+			methodVisitor.visitTypeInsn(NEW, "java/io/File");
+			methodVisitor.visitInsn(DUP);
+			methodVisitor.visitVarInsn(ALOAD, 2);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/net/URL", "toURI", "()Ljava/net/URI;", false);
+			methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/io/File", "<init>", "(Ljava/net/URI;)V", false);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/io/File", "getParentFile", "()Ljava/io/File;", false);
+			methodVisitor.visitMethodInsn(INVOKEVIRTUAL, "java/io/File", "getParentFile", "()Ljava/io/File;", false);
+			methodVisitor.visitVarInsn(ASTORE, 6);
+			methodVisitor.visitLabel(label13);
+			methodVisitor.visitLineNumber(41, label13);
+			methodVisitor.visitFrame(Opcodes.F_APPEND, 1, new Object[]{"java/io/File"}, 0, null);
+			methodVisitor.visitVarInsn(ALOAD, 0);
+			methodVisitor.visitVarInsn(ALOAD, 5);
+			methodVisitor.visitVarInsn(ALOAD, 6);
+			methodVisitor.visitMethodInsn(INVOKESTATIC, "net/minecraftforge/fml/relauncher/CoreModManager", "loadCoreMod", "(Lnet/minecraft/launchwrapper/LaunchClassLoader;Ljava/lang/String;Ljava/io/File;)Lnet/minecraftforge/fml/relauncher/CoreModManager$FMLPluginWrapper;", false);
+			methodVisitor.visitInsn(POP);
+			Label label15 = new Label();
+			methodVisitor.visitLabel(label15);
+			methodVisitor.visitLineNumber(42, label15);
+			methodVisitor.visitJumpInsn(GOTO, label1);
+			methodVisitor.visitLabel(label2);
+			methodVisitor.visitLineNumber(43, label2);
+			methodVisitor.visitFrame(Opcodes.F_FULL, 2, new Object[]{"net/minecraft/launchwrapper/LaunchClassLoader", "java/util/Enumeration"}, 0, new Object[]{});
+			methodVisitor.visitInsn(RETURN);
+			Label label16 = new Label();
+			methodVisitor.visitLabel(label16);
+			methodVisitor.visitLocalVariable("file", "Ljava/io/File;", null, label12, label10, 6);
+			methodVisitor.visitLocalVariable("url", "Ljava/net/URL;", null, label4, label15, 2);
+			methodVisitor.visitLocalVariable("stream", "Ljava/io/InputStream;", null, label5, label15, 3);
+			methodVisitor.visitLocalVariable("manifest", "Ljava/util/jar/Manifest;", null, label6, label15, 4);
+			methodVisitor.visitLocalVariable("coreModClass", "Ljava/lang/String;", null, label8, label15, 5);
+			methodVisitor.visitLocalVariable("file", "Ljava/io/File;", null, label13, label15, 6);
+			methodVisitor.visitLocalVariable("classLoader", "Lnet/minecraft/launchwrapper/LaunchClassLoader;", null, label0, label16, 0);
+			methodVisitor.visitLocalVariable("urls", "Ljava/util/Enumeration;", "Ljava/util/Enumeration<Ljava/net/URL;>;", label1, label16, 1);
+			methodVisitor.visitMaxs(8, 7);
+			methodVisitor.visitEnd();
+		}
+
+		super.visitEnd();
+	}
+
+	private static class InjectCallAtHead extends MethodVisitor {
+		private InjectCallAtHead(MethodVisitor methodVisitor) {
+			super(Opcodes.ASM9, methodVisitor);
+		}
+
+		@Override
+		public void visitCode() {
+			super.visitCode();
+
+			super.visitVarInsn(Opcodes.ALOAD, 1);
+			super.visitMethodInsn(Opcodes.INVOKESTATIC, CLASS, OUR_METHOD_NAME, OUR_METHOD_DESCRIPTOR, false);
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/srg/AccessTransformSetMapper.java
+++ b/src/main/java/net/fabricmc/loom/util/srg/AccessTransformSetMapper.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Minecrell (https://github.com/Minecrell)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package net.fabricmc.loom.util.srg;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.cadixdev.at.AccessTransformSet;
+import org.cadixdev.bombe.type.signature.MethodSignature;
+import org.cadixdev.lorenz.MappingSet;
+import org.cadixdev.lorenz.model.ClassMapping;
+import org.cadixdev.lorenz.model.FieldMapping;
+import org.cadixdev.lorenz.model.Mapping;
+import org.cadixdev.lorenz.model.MethodMapping;
+
+// TODO from https://github.com/CadixDev/at/blob/c2b92fc26cf26e64d3ca3b35abf3364d4b95e6c3/src/main/java/org/cadixdev/at/impl/AccessTransformSetMapper.java
+//      remove once https://github.com/CadixDev/at/issues/7 is fixed
+public final class AccessTransformSetMapper {
+	private AccessTransformSetMapper() {
+	}
+
+	public static AccessTransformSet remap(AccessTransformSet set, MappingSet mappings) {
+		Objects.requireNonNull(set, "set");
+		Objects.requireNonNull(mappings, "mappings");
+
+		AccessTransformSet remapped = AccessTransformSet.create();
+		set.getClasses().forEach((className, classSet) -> {
+			Optional<? extends ClassMapping<?, ?>> mapping = mappings.getClassMapping(className);
+			remap(mappings, mapping, classSet, remapped.getOrCreateClass(mapping.map(Mapping::getFullDeobfuscatedName).orElse(className)));
+		});
+		return remapped;
+	}
+
+	private static void remap(MappingSet mappings, Optional<? extends ClassMapping<?, ?>> mapping, AccessTransformSet.Class set, AccessTransformSet.Class remapped) {
+		remapped.merge(set.get());
+		remapped.mergeAllFields(set.allFields());
+		remapped.mergeAllMethods(set.allMethods());
+
+		set.getFields().forEach((name, transform) ->
+				remapped.mergeField(mapping.flatMap(m -> m.getFieldMapping(name))
+						.map(FieldMapping::getDeobfuscatedName).orElse(name), transform));
+
+		set.getMethods().forEach((signature, transform) ->
+				remapped.mergeMethod(mapping.flatMap(m -> m.getMethodMapping(signature))
+						.map(MethodMapping::getDeobfuscatedSignature)
+						.orElseGet(() -> new MethodSignature(signature.getName(), mappings.deobfuscate(signature.getDescriptor()))), transform));
+	}
+}

--- a/src/main/java/net/fabricmc/loom/util/srg/SrgNamedWriter.java
+++ b/src/main/java/net/fabricmc/loom/util/srg/SrgNamedWriter.java
@@ -36,18 +36,20 @@ import org.cadixdev.lorenz.io.srg.SrgWriter;
 import org.cadixdev.lorenz.model.ClassMapping;
 import org.cadixdev.lorenz.model.InnerClassMapping;
 import org.cadixdev.lorenz.model.TopLevelClassMapping;
-import org.gradle.api.logging.Logger;
 
 import net.fabricmc.lorenztiny.TinyMappingsReader;
 import net.fabricmc.mappingio.tree.MappingTree;
 
 public class SrgNamedWriter {
-	public static void writeTo(Logger logger, Path srgFile, MappingTree mappings, String from, String to) throws IOException {
+	public static void writeTo(Path srgFile, MappingTree mappings, String from, String to, boolean includeIdentityMappings) throws IOException {
 		Files.deleteIfExists(srgFile);
 
 		try (SrgWriter writer = new SrgWriter(Files.newBufferedWriter(srgFile))) {
 			try (TinyMappingsReader reader = new TinyMappingsReader(mappings, from, to)) {
-				writer.write(reader.read(MappingSet.create(new ClassesAlwaysHaveDeobfNameFactory())));
+				MappingSet mappingSet = includeIdentityMappings
+						? MappingSet.create(new ClassesAlwaysHaveDeobfNameFactory())
+						: MappingSet.create();
+				writer.write(reader.read(mappingSet));
 			}
 		}
 	}

--- a/src/test/groovy/net/fabricmc/loom/test/integration/forge/ForgeTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/forge/ForgeTest.groovy
@@ -54,5 +54,7 @@ class ForgeTest extends Specification implements GradleProjectTestTrait {
 			'1.16.5'  | "36.2.4"     | "\"net.fabricmc:yarn:1.16.5+build.5:v2\""
 			'1.14.4'  | "28.2.23"    | "loom.officialMojangMappings()"
 			'1.14.4'  | "28.2.23"    | "\"net.fabricmc:yarn:1.14.4+build.18:v2\""
+			'1.12.2'  | "14.23.0.2486" | "\"de.oceanlabs.mcp:mcp_snapshot:20170615-1.12\""
+			'1.8.9'   | "11.15.1.2318-1.8.9" | "\"de.oceanlabs.mcp:mcp_stable:22-1.8.9\""
 	}
 }

--- a/src/test/resources/projects/forge/simple/build.gradle
+++ b/src/test/resources/projects/forge/simple/build.gradle
@@ -57,6 +57,13 @@ jar {
 	}
 }
 
+loom {
+	forge {
+		// FIXME should eventually be handled by architectury-pack200 gradle plugin?
+		pack200Provider = new dev.architectury.pack200.java.Pack200Adapter()
+	}
+}
+
 // configure the maven publication
 publishing {
 	publications {


### PR DESCRIPTION
Adds support for Forge versions which previously required ForgeGradle 2.
Should be fully functional for building production-ready jars as well as running in a development environment (I only tested IntelliJ but there's no IDE-specific code).

This was developed mostly late November completely independently from #63. Afaict notable differences are:
- Significantly smaller diff; as few changes to FG3 code paths as possible (within reason)
- No FG code; instead of implementing the old patch algorithm, the old patches are converted to the modern format (which is surprisingly similar) when they are extracted (similarly, old srg files are converted to tsrg when extracted)
- Supports the TerminalConsoleAppender (by bumping the log4j version and merging the old "helper" classes, which forge depends on, into the forge jar), this may cause issues if mods depend on other parts of log4j that were changed between 2.0-beta9 and release (seems unlikely), but makes for MUCH better console output
- Access transformers are applied directly to the official-mapped jar (remapping the transformer on the fly) instead of converting the whole thing to srg and back
- The intermediary mappings are generated by stitch instead of manually traversing all classes
- Passes the forge/simple integration test case for 1.8.9 and 1.12.2

I had originally bundled pack200 directly into loom but later switched that out for the external plugin as in #63. I was unable to figure out a nice way to get it into the integration test though (classloader shenanigans where the plugin couldn't see our interface; and just adding it to the test classpath doesn't add it to the nested gradle jvm). The best I could come up with is adding a "runtimeOnly" dependency to the main project but is not ideal if the goal was to not have a dependency on that pack200 implementation (though the java classpath exception applies to it, so this shouldn't be an issue license-wise).

There's two extra commits before the main one, each of which fixes a bug I ran into (see their commit messages for details).

Somewhat complex example project: https://github.com/Sk1erLLC/Patcher/tree/tmp/archloom
(needs archloom published to mavenLocal; features a coremod, tweakers, mixins, 1.8.9 and 1.12.2)