### PR TITLE
Improvements to Quilt JiJ

### DIFF
--- a/src/main/java/net/fabricmc/loom/build/nesting/IncludedJarFactory.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/IncludedJarFactory.java
@@ -165,10 +165,7 @@ public final class IncludedJarFactory {
 		try {
 			FileUtils.copyFile(input, tempFile);
 
-			if (extension.getPlatform().get() == ModPlatform.QUILT) {
-				throw new UnsupportedOperationException("Generating Quilt mods for JiJ is not yet implemented!");
-			}
-
+			// TODO generate Quilt qmjs natively
 			ZipUtils.add(tempFile.toPath(), "fabric.mod.json", generateModForDependency(metadata).getBytes(StandardCharsets.UTF_8));
 		} catch (IOException e) {
 			throw new UncheckedIOException("Failed to add dummy mod while including %s".formatted(input), e);

--- a/src/main/java/net/fabricmc/loom/build/nesting/IncludedJarFactory.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/IncludedJarFactory.java
@@ -53,7 +53,6 @@ import org.jetbrains.annotations.Nullable;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.task.RemapTaskConfiguration;
-import net.fabricmc.loom.util.ModPlatform;
 import net.fabricmc.loom.util.ModUtils;
 import net.fabricmc.loom.util.ZipUtils;
 

--- a/src/main/java/net/fabricmc/loom/build/nesting/JarNester.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/JarNester.java
@@ -107,7 +107,7 @@ public class JarNester {
 
 				for (File file : jars) {
 					String nestedJarPath = "META-INF/jars/" + file.getName();
-					Preconditions.checkArgument(ModUtils.isMod(file, platform), "Cannot nest none mod jar: " + file.getName());
+					Preconditions.checkArgument(ModUtils.isMod(file, platform) || ModUtils.isMod(file, ModPlatform.FABRIC), "Cannot nest none mod jar: " + file.getName());
 
 					for (JsonElement nestedJar : nestedJars) {
 						String nestedJarString = nestedJar.getAsString();

--- a/src/main/java/net/fabricmc/loom/util/ModUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ModUtils.java
@@ -36,7 +36,7 @@ public final class ModUtils {
 		if (platform == ModPlatform.FORGE) {
 			return ZipUtils.contains(input.toPath(), "META-INF/mods.toml");
 		} else if (platform == ModPlatform.QUILT) {
-			return ZipUtils.contains(input.toPath(), "quilt.mod.json");
+			return ZipUtils.contains(input.toPath(), "quilt.mod.json") || ZipUtils.contains(input.toPath(), "fabric.mod.json");
 		}
 
 		return ZipUtils.contains(input.toPath(), "fabric.mod.json");

--- a/src/main/java/net/fabricmc/loom/util/ModUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ModUtils.java
@@ -36,7 +36,7 @@ public final class ModUtils {
 		if (platform == ModPlatform.FORGE) {
 			return ZipUtils.contains(input.toPath(), "META-INF/mods.toml");
 		} else if (platform == ModPlatform.QUILT) {
-			return ZipUtils.contains(input.toPath(), "quilt.mod.json") || ZipUtils.contains(input.toPath(), "fabric.mod.json");
+			return ZipUtils.contains(input.toPath(), "quilt.mod.json");
 		}
 
 		return ZipUtils.contains(input.toPath(), "fabric.mod.json");


### PR DESCRIPTION
There's no reason to throw an exception for generating FMJs instead of QMJs -- JiJed mods can still use an FMJ and work just fine

Also, return true for whether something is a mod on Quilt even if it has a fabric.mod.json
This is relevant in [JarNester.java:110](https://github.com/architectury/architectury-loom/blob/dev/0.11.0/src/main/java/net/fabricmc/loom/build/nesting/JarNester.java#L110)
