### PR TITLE
Replace compile-time package access fixing on Forge with Unprotect

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -200,6 +200,7 @@ public final class CompileConfiguration {
 
 		if (extension.isForge()) {
 			project.getDependencies().add(Constants.Configurations.FORGE_EXTRA, Constants.Dependencies.FORGE_RUNTIME + Constants.Dependencies.Versions.FORGE_RUNTIME);
+			project.getDependencies().add(Constants.Configurations.FORGE_EXTRA, Constants.Dependencies.UNPROTECT + Constants.Dependencies.Versions.UNPROTECT);
 			project.getDependencies().add(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME, Constants.Dependencies.JAVAX_ANNOTATIONS + Constants.Dependencies.Versions.JAVAX_ANNOTATIONS);
 		}
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
@@ -92,7 +92,7 @@ import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public class MinecraftPatchedProvider extends MergedMinecraftProvider {
 	private static final String LOOM_PATCH_VERSION_KEY = "Loom-Patch-Version";
-	private static final String CURRENT_LOOM_PATCH_VERSION = "5";
+	private static final String CURRENT_LOOM_PATCH_VERSION = "6";
 	private static final String NAME_MAPPING_SERVICE_PATH = "/inject/META-INF/services/cpw.mods.modlauncher.api.INameMappingService";
 
 	// Step 1: Remap Minecraft to SRG
@@ -250,7 +250,6 @@ public class MinecraftPatchedProvider extends MergedMinecraftProvider {
 				.withMappings(InnerClassRemapper.of(InnerClassRemapper.readClassNames(input), mappingsWithSrg, "srg", "official"))
 				.renameInvalidLocals(true)
 				.rebuildSourceFilenames(true)
-				.fixPackageAccess(true)
 				.build();
 
 		if (getProject().getGradle().getStartParameter().getLogLevel().compareTo(LogLevel.LIFECYCLE) < 0) {

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -126,6 +126,7 @@ public class Constants {
 		public static final String JAVAX_ANNOTATIONS = "com.google.code.findbugs:jsr305:"; // I hate that I have to add these.
 		public static final String FORGE_RUNTIME = "dev.architectury:architectury-loom-runtime:";
 		public static final String ACCESS_TRANSFORMERS = "net.minecraftforge:accesstransformers:";
+		public static final String UNPROTECT = "io.github.juuxel:unprotect:";
 
 		private Dependencies() {
 		}
@@ -143,6 +144,7 @@ public class Constants {
 			public static final String FORGE_RUNTIME = "1.1.3";
 			public static final String ACCESS_TRANSFORMERS = "3.0.1";
 			public static final String ACCESS_TRANSFORMERS_NEW = "8.0.5";
+			public static final String UNPROTECT = "1.0.0";
 
 			private Versions() {
 			}

--- a/src/main/java/net/fabricmc/loom/util/TinyRemapperHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/TinyRemapperHelper.java
@@ -106,13 +106,6 @@ public final class TinyRemapperHelper {
 				.logger(project.getLogger()::lifecycle)
 				.rebuildSourceFilenames(true);
 
-		if (extension.isForge()) {
-			/* FORGE: Required for classes like aej$OptionalNamedTag (1.16.4) which are added by Forge patches.
-			 * They won't get remapped to their proper packages, so IllegalAccessErrors will happen without ._.
-			 */
-			builder.fixPackageAccess(true);
-		}
-
 		builder.invalidLvNamePattern(MC_LV_PATTERN);
 		builder.inferNameFromSameLvIndex(true);
 		builder.extraPreApplyVisitor((cls, next) -> {


### PR DESCRIPTION
Unprotect does it at runtime as a ModLauncher plugin and also doesn't suffer from FabricMC/tiny-remapper#92.

- [x] Test with 1.16.5
- [x] Test with 1.18.2