### PR TITLE
Closer process to Forge Gradle's

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -100,6 +100,7 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 			});
 			repo.metadataSources(sources -> {
 				sources.mavenPom();
+				sources.artifact();
 				sources.ignoreGradleMetadataRedirection();
 			});
 		});

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
@@ -43,7 +43,12 @@ public class ForgeProvider extends DependencyProvider {
 	@Override
 	public void provide(DependencyInfo dependency) throws Exception {
 		version = new ForgeVersion(dependency.getResolvedVersion());
-		addDependency(dependency.getDepString() + ":userdev", Constants.Configurations.FORGE_USERDEV);
+		if (Runtime.Version.parse(version.getMinecraftVersion()).compareTo(Runtime.Version.parse("1.13")) < 0) {
+			// 1.12.2 and below have a different userdev classifier for ForgeGradle 3+ usage
+			addDependency(dependency.getDepString() + ":userdev3", Constants.Configurations.FORGE_USERDEV);
+		} else {
+			addDependency(dependency.getDepString() + ":userdev", Constants.Configurations.FORGE_USERDEV);
+		}
 		addDependency(dependency.getDepString() + ":installer", Constants.Configurations.FORGE_INSTALLER);
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
@@ -43,12 +43,14 @@ public class ForgeProvider extends DependencyProvider {
 	@Override
 	public void provide(DependencyInfo dependency) throws Exception {
 		version = new ForgeVersion(dependency.getResolvedVersion());
+
 		if (Runtime.Version.parse(version.getMinecraftVersion()).compareTo(Runtime.Version.parse("1.13")) < 0) {
 			// 1.12.2 and below have a different userdev classifier for ForgeGradle 3+ usage
 			addDependency(dependency.getDepString() + ":userdev3", Constants.Configurations.FORGE_USERDEV);
 		} else {
 			addDependency(dependency.getDepString() + ":userdev", Constants.Configurations.FORGE_USERDEV);
 		}
+
 		addDependency(dependency.getDepString() + ":installer", Constants.Configurations.FORGE_INSTALLER);
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
@@ -263,6 +263,8 @@ public class ForgeUserdevProvider extends DependencyProvider {
 				string = String.join(File.pathSeparator, modClasses);
 			} else if (key.equals("mcp_mappings")) {
 				string = "loom.stub";
+			} else if (key.equals("mcp_to_srg")) {
+				string = getExtension().getMappingsProvider().srgToNamedSrg.toAbsolutePath().toString();
 			} else if (json.has(key)) {
 				JsonElement element = json.get(key);
 
@@ -301,6 +303,10 @@ public class ForgeUserdevProvider extends DependencyProvider {
 
 	public File getUserdevJar() {
 		return userdevJar;
+	}
+
+	public JsonObject getConfig() {
+		return json;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/McpConfigProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/McpConfigProvider.java
@@ -174,19 +174,23 @@ public class McpConfigProvider extends DependencyProvider {
 
 		protected void execute() throws IOException {
 			String mainClass;
-			try (var jar = new JarFile(mainClasspath)) {
+
+			try (JarFile jar = new JarFile(mainClasspath)) {
 				mainClass = jar.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS);
 			}
 
 			ForgeToolExecutor.exec(project, spec -> {
 				List<String> specArgs = new ArrayList<>();
+
 				for (String arg : args) {
 					if (argumentTemplates != null) {
-						final var replacement = argumentTemplates.get(arg);
+						Collection<String> replacement = argumentTemplates.get(arg);
+
 						if (replacement != null) {
 							if (replacement.size() > 1) {
 								specArgs.remove(specArgs.size() - 1);
 							}
+
 							specArgs.addAll(replacement);
 						} else {
 							specArgs.add(arg);

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingsSpec.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingsSpec.java
@@ -30,8 +30,8 @@ import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
 
 public record MojangMappingsSpec(SilenceLicenseOption silenceLicense, boolean nameSyntheticMembers) implements MappingsSpec<MojangMappingLayer> {
 	// Keys in dependency manifest
-	private static final String MANIFEST_CLIENT_MAPPINGS = "client_mappings";
-	private static final String MANIFEST_SERVER_MAPPINGS = "server_mappings";
+	public static final String MANIFEST_CLIENT_MAPPINGS = "client_mappings";
+	public static final String MANIFEST_SERVER_MAPPINGS = "server_mappings";
 
 	public MojangMappingsSpec(SilenceLicenseSupplier supplier, boolean nameSyntheticMembers) {
 		this(new SilenceLicenseOption(supplier), nameSyntheticMembers);

--- a/src/main/java/net/fabricmc/loom/util/srg/SpecialSourceExecutor.java
+++ b/src/main/java/net/fabricmc/loom/util/srg/SpecialSourceExecutor.java
@@ -97,7 +97,7 @@ public class SpecialSourceExecutor {
 		return stripped;
 	}
 
-	public static Path produceSrgJar(McpConfigProvider.RemapAction remapAction, Project project, String side, Path officialJar, Path mappings)
+	public static Path produceSrgJar(McpConfigProvider.RemapAction remapAction, Project project, String side, Set<File> mcLibs, Path officialJar, Path mappings)
 			throws IOException {
 		Path output = LoomGradleExtension.get(project).getFiles().getProjectBuildCache().toPath().resolve(officialJar.getFileName().toString().substring(0, officialJar.getFileName().toString().length() - 4) + "-srg-output.jar");
 		Files.deleteIfExists(output);
@@ -105,7 +105,7 @@ public class SpecialSourceExecutor {
 		Stopwatch stopwatch = Stopwatch.createStarted();
 
 		project.getLogger().lifecycle(":remapping minecraft (" + remapAction + ", " + side + ", official -> srg)");
-		remapAction.execute(officialJar, output, mappings);
+		remapAction.execute(officialJar, output, mappings, mcLibs);
 		project.getLogger().lifecycle(":remapped minecraft (" + remapAction + ", " + side + ", official -> srg) in " + stopwatch.stop());
 
 		Files.deleteIfExists(officialJar);


### PR DESCRIPTION
This revamps the process of merging and patching by using the userdev and mcp configs more instead of assuming where everything is. This also uses the official userdev patches instead of getting them from the installer jar.

I also changed the userdev classifier to userdev3 for versions lower than 1.13, which can with the rest of the changes allow 1.12.2 or any other legacy FG3 versions to work.

Tested with:
1.12.2 with MCP(with a bit of extra configuring on the mod's part)
1.14.4 with MCP, Mojmaps
1.16.5 with MCP, Mojmaps
1.18.2 with Mojmaps

One side effect of this is now the Forge merged Jars use Forge's annotations, which shouldn't effect anything, but if that's not reasonable then I could post process the merged Jar to replace the annotations with fabric's.

(Note: this also does what #10 does, as I was unable to use MCP mappings for most versions without it.)