### PR TITLE
Support older FG3 game versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ dependencies {
 
 	// Forge patches
 	implementation ('net.minecraftforge:installertools:1.2.0')
+	implementation ('net.minecraftforge:srgutils:0.4.11')
 	implementation ('org.cadixdev:lorenz:0.5.3')
 	implementation ('org.cadixdev:lorenz-asm:0.5.3')
 	implementation ('de.oceanlabs.mcp:mcinjector:3.8.0')

--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -99,6 +99,7 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 				descriptor.excludeGroup("org.ow2.asm");
 			});
 			repo.metadataSources(sources -> {
+				sources.artifact();
 				sources.mavenPom();
 				sources.ignoreGradleMetadataRedirection();
 			});

--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -427,7 +427,11 @@ public final class CompileConfiguration {
 
 		if (extension.isForge()) {
 			dependencyProviders.addProvider(new McpConfigProvider(project));
-			dependencyProviders.addProvider(new PatchProvider(project));
+
+			if (((ForgeMinecraftProvider) extension.getMinecraftProvider()).requiresPatchProvider()) {
+				dependencyProviders.addProvider(new PatchProvider(project));
+			}
+
 			dependencyProviders.addProvider(new ForgeUniversalProvider(project));
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/FieldMigratedMappingsProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/FieldMigratedMappingsProvider.java
@@ -60,7 +60,6 @@ import net.fabricmc.loom.configuration.providers.mappings.MappingsProviderImpl;
 import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.ThreadingUtils;
-import net.fabricmc.loom.util.srg.SrgMerger;
 import net.fabricmc.mappingio.MappingReader;
 import net.fabricmc.mappingio.format.Tiny2Writer;
 import net.fabricmc.mappingio.tree.MappingTree;
@@ -80,8 +79,8 @@ public class FieldMigratedMappingsProvider extends MappingsProviderImpl {
 	@Override
 	protected void setup(Project project, MinecraftProvider minecraftProvider, Path inputJar) throws IOException {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
-		PatchProvider patchProvider = extension.getPatchProvider();
-		migratedFieldsCache = patchProvider.getProjectCacheFolder().resolve("migrated-fields.json");
+		ForgeProvider forgeProvider = extension.getForgeProvider();
+		migratedFieldsCache = forgeProvider.getGlobalCache().toPath().resolve("migrated-fields.json");
 		migratedFields.clear();
 
 		if (LoomGradlePlugin.refreshDeps) {
@@ -114,9 +113,7 @@ public class FieldMigratedMappingsProvider extends MappingsProviderImpl {
 
 		if (extension.shouldGenerateSrgTiny()) {
 			if (Files.notExists(rawTinyMappingsWithSrg) || isRefreshDeps()) {
-				// Merge tiny mappings with srg
-				SrgMerger.ExtraMappings extraMappings = SrgMerger.ExtraMappings.ofMojmapTsrg(getMojmapSrgFileIfPossible(project));
-				SrgMerger.mergeSrg(getRawSrgFile(project), rawTinyMappings, rawTinyMappingsWithSrg, extraMappings, true);
+				mergeSrg(project, rawTinyMappings, rawTinyMappingsWithSrg);
 			}
 		}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
@@ -43,7 +43,15 @@ public class ForgeProvider extends DependencyProvider {
 	@Override
 	public void provide(DependencyInfo dependency) throws Exception {
 		version = new ForgeVersion(dependency.getResolvedVersion());
-		addDependency(dependency.getDepString() + ":userdev", Constants.Configurations.FORGE_USERDEV);
+		String userdevClassifier;
+
+		if (Runtime.Version.parse(version.getMinecraftVersion()).compareTo(Runtime.Version.parse("1.13")) < 0) {
+			userdevClassifier = "userdev3";
+		} else {
+			userdevClassifier = "userdev";
+		}
+
+		addDependency(dependency.getDepString() + ":" + userdevClassifier, Constants.Configurations.FORGE_USERDEV);
 		addDependency(dependency.getDepString() + ":installer", Constants.Configurations.FORGE_INSTALLER);
 	}
 

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
@@ -25,6 +25,7 @@
 package net.fabricmc.loom.configuration.providers.forge;
 
 import java.io.File;
+import java.util.Arrays;
 
 import org.gradle.api.Project;
 
@@ -32,6 +33,7 @@ import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.util.Constants;
 
 public class ForgeProvider extends DependencyProvider {
+	private static final int[] MC_1_13 = {1, 13};
 	private ForgeVersion version = new ForgeVersion(null);
 	private File globalCache;
 	private File projectCache;
@@ -44,8 +46,16 @@ public class ForgeProvider extends DependencyProvider {
 	public void provide(DependencyInfo dependency) throws Exception {
 		version = new ForgeVersion(dependency.getResolvedVersion());
 		String userdevClassifier;
+		boolean legacy;
 
-		if (Runtime.Version.parse(version.getMinecraftVersion()).compareTo(Runtime.Version.parse("1.13")) < 0) {
+		try {
+			int[] parts = Arrays.stream(version.getMinecraftVersion().split("\\.")).mapToInt(Integer::parseInt).toArray();
+			legacy = Arrays.compare(parts, MC_1_13) < 0;
+		} catch (NumberFormatException exception) {
+			legacy = false;
+		}
+
+		if (legacy) {
 			userdevClassifier = "userdev3";
 		} else {
 			userdevClassifier = "userdev";

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
@@ -25,15 +25,14 @@
 package net.fabricmc.loom.configuration.providers.forge;
 
 import java.io.File;
-import java.util.Arrays;
 
+import net.minecraftforge.srgutils.MinecraftVersion;
 import org.gradle.api.Project;
 
 import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.util.Constants;
 
 public class ForgeProvider extends DependencyProvider {
-	private static final int[] MC_1_13 = {1, 13};
 	private ForgeVersion version = new ForgeVersion(null);
 	private File globalCache;
 	private File projectCache;
@@ -46,16 +45,8 @@ public class ForgeProvider extends DependencyProvider {
 	public void provide(DependencyInfo dependency) throws Exception {
 		version = new ForgeVersion(dependency.getResolvedVersion());
 		String userdevClassifier;
-		boolean legacy;
 
-		try {
-			int[] parts = Arrays.stream(version.getMinecraftVersion().split("\\.")).mapToInt(Integer::parseInt).toArray();
-			legacy = Arrays.compare(parts, MC_1_13) < 0;
-		} catch (NumberFormatException exception) {
-			legacy = false;
-		}
-
-		if (legacy) {
+		if (MinecraftVersion.from(version.getMinecraftVersion()).compareTo(MinecraftVersion.from("1.13")) < 0) {
 			userdevClassifier = "userdev3";
 		} else {
 			userdevClassifier = "userdev";

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
@@ -159,7 +159,7 @@ public class ForgeUserdevProvider extends DependencyProvider {
 		if (Files.notExists(accessTransformerConfig)) {
 			try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(userdevJar.toPath(), false)) {
 				for (JsonElement element : json.getAsJsonArray("ats")) {
-					Files.write(accessTransformerConfig, fs.readAllBytes(element.getAsString()), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+					Files.write(accessTransformerConfig, fs.readAllBytes(element.getAsString()), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND);
 				}
 			}
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeUserdevProvider.java
@@ -50,11 +50,6 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
-import net.fabricmc.loom.api.ModSettings;
-
-import net.fabricmc.loom.util.gradle.SourceSetHelper;
-
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
@@ -69,6 +64,7 @@ import org.gradle.api.provider.Provider;
 
 import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.api.ForgeLocalMod;
+import net.fabricmc.loom.api.ModSettings;
 import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
 import net.fabricmc.loom.configuration.launch.LaunchProviderSettings;
@@ -77,6 +73,7 @@ import net.fabricmc.loom.util.DependencyDownloader;
 import net.fabricmc.loom.util.FileSystemUtil;
 import net.fabricmc.loom.util.PropertyUtil;
 import net.fabricmc.loom.util.ZipUtils;
+import net.fabricmc.loom.util.gradle.SourceSetHelper;
 
 public class ForgeUserdevProvider extends DependencyProvider {
 	private List<Pattern> filters;

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
@@ -652,7 +652,8 @@ public class MinecraftPatchedProvider {
 	public class UserdevFilter implements OutputConsumerPath.ResourceRemapper {
 		@Override
 		public boolean canTransform(TinyRemapper tinyRemapper, Path path) {
-			return getExtension().getForgeUserdevProvider().getUniversalFilters().stream().noneMatch(pattern -> pattern.matcher(path.toString()).matches());
+			List<Pattern> patterns = getExtension().getForgeUserdevProvider().getUniversalFilters();
+			return !patterns.isEmpty() && patterns.stream().noneMatch(pattern -> pattern.matcher(path.toString()).matches());
 		}
 
 		@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
@@ -241,7 +241,7 @@ public class MinecraftPatchedProvider {
 
 		if (isNotchObf) {
 			if (dirty || Files.notExists(minecraftPatchedSrgJar)) {
-				File specialSource = DependencyDownloader.download(project, "net.md-5:SpecialSource:1.10.0:shaded", false, false).getSingleFile();
+				File specialSource = DependencyDownloader.download(project, Constants.Dependencies.SPECIAL_SOURCE, false, false).getSingleFile();
 				String mainClass;
 
 				try (JarFile jarFile = new JarFile(specialSource)) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
@@ -111,7 +111,7 @@ public class MinecraftPatchedProvider {
 	// Step 3: Access Transform
 	private Path minecraftPatchedSrgAtJar;
 	// Step 4: Remap Patched AT & Forge to official
-	private Path minecraftPatchedOfficialJar;
+	private Path minecraftPatchedAtJar;
 	private Path minecraftClientExtra;
 
 	private boolean dirty = false;
@@ -161,7 +161,7 @@ public class MinecraftPatchedProvider {
 
 		minecraftPatchedSrgJar = forgeWorkingDir.resolve("minecraft-" + type.id + "-srg-patched.jar");
 		minecraftPatchedSrgAtJar = forgeWorkingDir.resolve("minecraft-" + type.id + "-srg-at-patched.jar");
-		minecraftPatchedOfficialJar = forgeWorkingDir.resolve("minecraft-" + type.id + "-official--patched.jar");
+		minecraftPatchedAtJar = forgeWorkingDir.resolve("minecraft-" + type.id + "-at-patched.jar");
 		minecraftClientExtra = forgeWorkingDir.resolve("forge-client-extra.jar");
 	}
 
@@ -178,7 +178,7 @@ public class MinecraftPatchedProvider {
 					minecraftPatchedJar,
 					minecraftPatchedSrgJar,
 					minecraftPatchedSrgAtJar,
-					minecraftPatchedOfficialJar,
+					minecraftPatchedAtJar,
 					minecraftClientExtra,
 			};
 		}
@@ -187,14 +187,14 @@ public class MinecraftPatchedProvider {
 				minecraftSrgJar,
 				minecraftPatchedSrgJar,
 				minecraftPatchedSrgAtJar,
-				minecraftPatchedOfficialJar,
+				minecraftPatchedAtJar,
 				minecraftClientExtra,
 		};
 	}
 
 	private void checkCache() throws IOException {
 		if (LoomGradlePlugin.refreshDeps || Stream.of(getGlobalCaches()).anyMatch(Files::notExists)
-				|| !isPatchedJarUpToDate(minecraftPatchedOfficialJar)) {
+				|| !isPatchedJarUpToDate(minecraftPatchedAtJar)) {
 			cleanAllCache();
 		}
 	}
@@ -477,7 +477,7 @@ public class MinecraftPatchedProvider {
 	private void remapPatchedJar() throws Exception {
 		logger.lifecycle(":remapping minecraft (TinyRemapper, srg -> official)");
 		Path mcInput = minecraftPatchedSrgAtJar;
-		Path mcOutput = minecraftPatchedOfficialJar;
+		Path mcOutput = minecraftPatchedAtJar;
 		Files.deleteIfExists(mcOutput);
 
 		TinyRemapper remapper = buildRemapper(mcInput);
@@ -632,7 +632,7 @@ public class MinecraftPatchedProvider {
 	}
 
 	public Path getMinecraftPatchedJar() {
-		return minecraftPatchedOfficialJar;
+		return minecraftPatchedAtJar;
 	}
 
 	public enum Type {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/PatchProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/PatchProvider.java
@@ -24,8 +24,6 @@
 
 package net.fabricmc.loom.configuration.providers.forge;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -42,7 +40,6 @@ import net.fabricmc.loom.util.Constants;
 public class PatchProvider extends DependencyProvider {
 	public Path clientPatches;
 	public Path serverPatches;
-	public Path projectCacheFolder;
 
 	public PatchProvider(Project project) {
 		super(project);
@@ -50,7 +47,9 @@ public class PatchProvider extends DependencyProvider {
 
 	@Override
 	public void provide(DependencyInfo dependency) throws Exception {
-		init(dependency.getDependency().getVersion());
+		Path cacheFolder = getExtension().getForgeProvider().getGlobalCache().toPath();
+		clientPatches = cacheFolder.resolve("patches-client.lzma");
+		serverPatches = cacheFolder.resolve("patches-server.lzma");
 
 		if (Files.notExists(clientPatches) || Files.notExists(serverPatches) || isRefreshDeps()) {
 			getProject().getLogger().info(":extracting forge patches");
@@ -62,22 +61,6 @@ public class PatchProvider extends DependencyProvider {
 				Files.copy(fs.getPath("data", "server.lzma"), serverPatches, StandardCopyOption.REPLACE_EXISTING);
 			}
 		}
-	}
-
-	private void init(String forgeVersion) {
-		projectCacheFolder = getMinecraftProvider().dir("forge/" + forgeVersion).toPath();
-		clientPatches = projectCacheFolder.resolve("patches-client.lzma");
-		serverPatches = projectCacheFolder.resolve("patches-server.lzma");
-
-		try {
-			Files.createDirectories(projectCacheFolder);
-		} catch (IOException e) {
-			throw new UncheckedIOException(e);
-		}
-	}
-
-	public Path getProjectCacheFolder() {
-		return projectCacheFolder;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/minecraft/ForgeMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/minecraft/ForgeMinecraftProvider.java
@@ -38,6 +38,8 @@ import net.fabricmc.loom.configuration.providers.minecraft.SingleJarMinecraftPro
 public interface ForgeMinecraftProvider {
 	MinecraftPatchedProvider getPatchedProvider();
 
+	boolean requiresPatchProvider();
+
 	static MergedMinecraftProvider createMerged(Project project) {
 		return LoomGradleExtension.get(project).isForge() ? new MergedForgeMinecraftProvider(project) : new MergedMinecraftProvider(project);
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/minecraft/MergedForgeMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/minecraft/MergedForgeMinecraftProvider.java
@@ -66,4 +66,9 @@ public final class MergedForgeMinecraftProvider extends MergedMinecraftProvider 
 	public MinecraftPatchedProvider getPatchedProvider() {
 		return patchedProvider;
 	}
+
+	@Override
+	public boolean requiresPatchProvider() {
+		return false;
+	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/minecraft/SingleJarForgeMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/minecraft/SingleJarForgeMinecraftProvider.java
@@ -65,6 +65,11 @@ public final class SingleJarForgeMinecraftProvider extends SingleJarMinecraftPro
 	}
 
 	@Override
+	public boolean requiresPatchProvider() {
+		return true;
+	}
+
+	@Override
 	public Path getMinecraftEnvOnlyJar() {
 		return patchedProvider.getMinecraftPatchedJar();
 	}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingsProviderImpl.java
@@ -107,7 +107,6 @@ public class MappingsProviderImpl implements MappingsProvider, SharedService {
 	private final Path mcpToSrg;
 	private final Path unpickDefinitions;
 
-
 	private boolean hasUnpickDefinitions;
 	private UnpickMetadata unpickMetadata;
 	private Map<String, String> signatureFixes;
@@ -162,6 +161,7 @@ public class MappingsProviderImpl implements MappingsProvider, SharedService {
 
 			try {
 				Files.copy(srgToNamedSrg, mcpToSrg, StandardCopyOption.REPLACE_EXISTING);
+
 				for (MappingTree.ClassMapping missingClass : getMappingsWithSrg().getClasses()) {
 					String srg = missingClass.getName(MappingsNamespace.SRG.toString());
 					String named = missingClass.getName(MappingsNamespace.NAMED.toString());

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingsSpec.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/mojmap/MojangMappingsSpec.java
@@ -30,8 +30,8 @@ import net.fabricmc.loom.configuration.providers.minecraft.MinecraftVersionMeta;
 
 public record MojangMappingsSpec(SilenceLicenseOption silenceLicense, boolean nameSyntheticMembers) implements MappingsSpec<MojangMappingLayer> {
 	// Keys in dependency manifest
-	private static final String MANIFEST_CLIENT_MAPPINGS = "client_mappings";
-	private static final String MANIFEST_SERVER_MAPPINGS = "server_mappings";
+	public static final String MANIFEST_CLIENT_MAPPINGS = "client_mappings";
+	public static final String MANIFEST_SERVER_MAPPINGS = "server_mappings";
 
 	public MojangMappingsSpec(SilenceLicenseSupplier supplier, boolean nameSyntheticMembers) {
 		this(new SilenceLicenseOption(supplier), nameSyntheticMembers);

--- a/src/main/java/net/fabricmc/loom/util/Constants.java
+++ b/src/main/java/net/fabricmc/loom/util/Constants.java
@@ -134,6 +134,8 @@ public class Constants {
 		public static final String UNPROTECT = "io.github.juuxel:unprotect:";
 		// Used to upgrade the ASM version for the AT tool.
 		public static final String ASM = "org.ow2.asm:asm:";
+		// Forge versions with the `notchObf` version enabled in their userdev config(typically < 1.13) require an extra remapping step that uses this.
+		public static final String SPECIAL_SOURCE = "net.md-5:SpecialSource:1.10.0:shaded";
 
 		private Dependencies() {
 		}


### PR DESCRIPTION
This redoes some of what #86 did, specifically the parts supporting legacy FG3 versions.
The gist of what this does is:

- Checking for more userdev config options, specifically `notchObf`, `ats`, and `universalFilters` since they are needed for legacy to work
- Changing the step order for patching the Jars if `notchObf` is true
- Changing the userdev classifier for versions lower than 1.13
- Only merging SRG mappings with official mappings on versions that support them
- Supporting the `mcp_to_srg` template argument option, and also adding unmapped class names to the SRG mappings file as they are needed in older versions.
- Not adding the patch provider unless it is required(and failing if single Jar is used with versions that had a different installer format)
