### PR TITLE
Greatly reduced memory usage by excluding unnecessary classpaths from remap task

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -158,7 +158,10 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 	public RemapJarTask() {
 		super();
 
+		// Lazy provider because minecraftNamed is not available at this point
 		getClasspath().from(getProject().provider(() -> getProject().getConfigurations().getByName("minecraftNamed").copy()));
+		getClasspath().from(getProject().getConfigurations().getByName("modCompileClasspath"));
+
 		getAddNestedDependencies().convention(true).finalizeValueOnRead();
 		getReadMixinConfigsFromManifest().convention(LoomGradleExtension.get(getProject()).isForge()).finalizeValueOnRead();
 		getInjectAccessWidener().convention(false);

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -152,13 +152,13 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 	@Input
 	public abstract Property<Boolean> getInjectAccessWidener();
 
-	private Supplier<TinyRemapperService> tinyRemapperService = Suppliers.memoize(() -> TinyRemapperService.getOrCreate(this));
+	private final Supplier<TinyRemapperService> tinyRemapperService = Suppliers.memoize(() -> TinyRemapperService.getOrCreate(this));
 
 	@Inject
 	public RemapJarTask() {
 		super();
 
-		getClasspath().from(getProject().getConfigurations().getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME));
+		getClasspath().from(getProject().provider(() -> getProject().getConfigurations().getByName("minecraftNamed").copy()));
 		getAddNestedDependencies().convention(true).finalizeValueOnRead();
 		getReadMixinConfigsFromManifest().convention(LoomGradleExtension.get(getProject()).isForge()).finalizeValueOnRead();
 		getInjectAccessWidener().convention(false);


### PR DESCRIPTION
Using `JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME`/`complileClasspath` causes all the compile time dependencies such as user-defined external libraries and Minecraft libraries to be included in the remapping classpath. Those could be a huge amount of jars and classes, which could consume a lot of memory when they get read by TinyRemapper. Especially in projects with multiple modules, it could force a full GC and slow down the build process.
Only the `modCompileClasspath` (libraries to be remapped) and `minecraftNamed` (remapped mc jar for development environment) are needed for remapping as they are the only ones relevant to mapping.

Before:
![before](https://user-images.githubusercontent.com/62033805/207523699-f9aea02c-cb2c-410a-8ccc-b5bb528784eb.png)
![before time](https://user-images.githubusercontent.com/62033805/207523750-efe1a296-46e1-4c49-8f5b-217244a60e5d.png)

After:
![after](https://user-images.githubusercontent.com/62033805/207523778-ab4beebc-cf44-461e-b098-a3c3076d9631.png)
![after time](https://user-images.githubusercontent.com/62033805/207523793-14b3f22a-5e65-41f5-94e9-7503eccd2def.png)