### PR TITLE
Fixed refmap naming conflicts by including root project name

### DIFF
--- a/src/main/java/net/fabricmc/loom/extension/MixinExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/MixinExtensionImpl.java
@@ -71,7 +71,7 @@ public class MixinExtensionImpl extends MixinExtensionApiImpl implements MixinEx
 		String defaultRefmapName = project.getExtensions().getByType(BasePluginExtension.class).getArchivesName().get() + "-refmap.json";
 
 		if (project.getRootProject() != project) {
-			defaultRefmapName = project.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + "-" + project.getPath().replaceFirst(":", "").replace(':', '_') + "-refmap.json";
+			defaultRefmapName = project.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + "-" + project.getRootProject().getName() + project.getPath().replace(':', '_') + "-refmap.json";
 		}
 
 		project.getLogger().info("Could not find refmap definition, will be using default name: " + defaultRefmapName);


### PR DESCRIPTION
The old refmap naming fix (e130d9b1) in architectury-loom doesn't include root project name. Which could still lead to refmap conflicts between architectury mods.
For Example:
```
ExampleModA
├── common
├── fabric
└── forge

ExampleModB
├── common
├── fabric
└── forge
```
They will have the same refmap names: `common-common-refmap.json`, `fabric-fabric-refmap.json`,  `forge-forge-refmap.json`.
Because the only unique identifier is their root project name, `ExampleModA` and `ExampleModB`. Including the root project name should fix this and gives unique names: `common-ExampleModA_common-refmap.json`, `common-ExampleModB_common-refmap.json`, etc.