### PR TITLE
Split Architectury extensions to Fabric classes into new classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,7 @@ spotless {
 	java {
 		licenseHeaderFile(rootProject.file("HEADER")).yearSeparator("-")
 		targetExclude("**/loom/util/DownloadUtil.java", "**/loom/util/FileSystemUtil.java")
+		targetExclude("**/dev/architectury/**")
 	}
 
 	groovy {

--- a/src/main/java/dev/architectury/loom/extensions/ModBuildExtensions.java
+++ b/src/main/java/dev/architectury/loom/extensions/ModBuildExtensions.java
@@ -1,0 +1,101 @@
+package dev.architectury.loom.extensions;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import org.cadixdev.at.AccessTransformSet;
+import org.cadixdev.at.io.AccessTransformFormats;
+import org.cadixdev.lorenz.MappingSet;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.jetbrains.annotations.Nullable;
+
+import net.fabricmc.loom.task.service.MappingsService;
+import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.FileSystemUtil;
+import net.fabricmc.loom.util.LfWriter;
+import net.fabricmc.loom.util.aw2at.Aw2At;
+import net.fabricmc.loom.util.service.UnsafeWorkQueueHelper;
+import net.fabricmc.lorenztiny.TinyMappingsReader;
+
+public final class ModBuildExtensions {
+	public static Set<String> readMixinConfigsFromManifest(File jarFile) {
+		try (JarFile jar = new JarFile(jarFile)) {
+			@Nullable Manifest manifest = jar.getManifest();
+
+			if (manifest != null) {
+				Attributes attributes = manifest.getMainAttributes();
+				String mixinConfigs = attributes.getValue(Constants.Forge.MIXIN_CONFIGS_MANIFEST_KEY);
+
+				if (mixinConfigs != null) {
+					return Set.of(mixinConfigs.split(","));
+				}
+			}
+
+			return Set.of();
+		} catch (IOException e) {
+			throw new UncheckedIOException("Could not read mixin configs from jar " + jarFile.getAbsolutePath(), e);
+		}
+	}
+
+	public static void convertAwToAt(SetProperty<String> atAccessWidenersProperty, Path outputFile, Property<String> mappingBuildServiceUuid) throws IOException {
+		if (!atAccessWidenersProperty.isPresent()) {
+			return;
+		}
+
+		Set<String> atAccessWideners = atAccessWidenersProperty.get();
+
+		if (atAccessWideners.isEmpty()) {
+			return;
+		}
+
+		AccessTransformSet at = AccessTransformSet.create();
+
+		try (FileSystemUtil.Delegate fileSystem = FileSystemUtil.getJarFileSystem(outputFile, false)) {
+			FileSystem fs = fileSystem.get();
+			Path atPath = fs.getPath(Constants.Forge.ACCESS_TRANSFORMER_PATH);
+
+			if (Files.exists(atPath)) {
+				throw new FileAlreadyExistsException("Jar " + outputFile + " already contains an access transformer - cannot convert AWs!");
+			}
+
+			for (String aw : atAccessWideners) {
+				Path awPath = fs.getPath(aw);
+
+				if (Files.notExists(awPath)) {
+					throw new NoSuchFileException("Could not find AW '" + aw + "' to convert into AT!");
+				}
+
+				try (BufferedReader reader = Files.newBufferedReader(awPath, StandardCharsets.UTF_8)) {
+					at.merge(Aw2At.toAccessTransformSet(reader));
+				}
+
+				Files.delete(awPath);
+			}
+
+			MappingsService service = UnsafeWorkQueueHelper.get(mappingBuildServiceUuid, MappingsService.class);
+
+			try (TinyMappingsReader reader = new TinyMappingsReader(service.getMemoryMappingTree(), service.getFromNamespace(), service.getToNamespace())) {
+				MappingSet mappingSet = reader.read();
+				at = at.remap(mappingSet);
+			}
+
+			try (Writer writer = new LfWriter(Files.newBufferedWriter(atPath))) {
+				AccessTransformFormats.FML.write(writer, at);
+			}
+		}
+	}
+}

--- a/src/main/java/dev/architectury/loom/metadata/ArchitecturyCommonJson.java
+++ b/src/main/java/dev/architectury/loom/metadata/ArchitecturyCommonJson.java
@@ -1,0 +1,89 @@
+package dev.architectury.loom.metadata;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.Nullable;
+
+import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
+
+public final class ArchitecturyCommonJson implements ModMetadataFile {
+	private static final String ACCESS_WIDENER_KEY = "accessWidener";
+
+	private final JsonObject json;
+
+	private ArchitecturyCommonJson(JsonObject json) {
+		this.json = Objects.requireNonNull(json, "json");
+	}
+
+	public static ArchitecturyCommonJson of(byte[] utf8) {
+		return of(new String(utf8, StandardCharsets.UTF_8));
+	}
+
+	public static ArchitecturyCommonJson of(String text) {
+		return of(LoomGradlePlugin.GSON.fromJson(text, JsonObject.class));
+	}
+
+	public static ArchitecturyCommonJson of(Path path) throws IOException {
+		return of(Files.readString(path, StandardCharsets.UTF_8));
+	}
+
+	public static ArchitecturyCommonJson of(File file) throws IOException {
+		return of(file.toPath());
+	}
+
+	public static ArchitecturyCommonJson of(JsonObject json) {
+		return new ArchitecturyCommonJson(json);
+	}
+
+	@Override
+	public @Nullable String getAccessWidener() {
+		if (json.has(ACCESS_WIDENER_KEY)) {
+			return json.get(ACCESS_WIDENER_KEY).getAsString();
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public List<InterfaceInjectionProcessor.InjectedInterface> getInjectedInterfaces(@Nullable String modId) {
+		if (modId == null) {
+			throw new IllegalArgumentException("visitInjectedInterfaces: mod ID has to be provided for architectury.common.json");
+		}
+
+		return getInjectedInterfaces(json, modId);
+	}
+
+	static List<InterfaceInjectionProcessor.InjectedInterface> getInjectedInterfaces(JsonObject json, String modId) {
+		Objects.requireNonNull(modId, "mod ID");
+
+		if (json.has("injected_interfaces")) {
+			JsonObject addedIfaces = json.getAsJsonObject("injected_interfaces");
+
+			final List<InterfaceInjectionProcessor.InjectedInterface> result = new ArrayList<>();
+
+			for (String className : addedIfaces.keySet()) {
+				final JsonArray ifaceNames = addedIfaces.getAsJsonArray(className);
+
+				for (JsonElement ifaceName : ifaceNames) {
+					result.add(new InterfaceInjectionProcessor.InjectedInterface(modId, className, ifaceName.getAsString()));
+				}
+			}
+
+			return result;
+		}
+
+		return Collections.emptyList();
+	}
+}

--- a/src/main/java/dev/architectury/loom/metadata/ArchitecturyCommonJson.java
+++ b/src/main/java/dev/architectury/loom/metadata/ArchitecturyCommonJson.java
@@ -59,7 +59,7 @@ public final class ArchitecturyCommonJson implements ModMetadataFile {
 	@Override
 	public List<InterfaceInjectionProcessor.InjectedInterface> getInjectedInterfaces(@Nullable String modId) {
 		if (modId == null) {
-			throw new IllegalArgumentException("visitInjectedInterfaces: mod ID has to be provided for architectury.common.json");
+			throw new IllegalArgumentException("getInjectedInterfaces: mod ID has to be provided for architectury.common.json");
 		}
 
 		return getInjectedInterfaces(json, modId);

--- a/src/main/java/dev/architectury/loom/metadata/ModMetadataFile.java
+++ b/src/main/java/dev/architectury/loom/metadata/ModMetadataFile.java
@@ -1,0 +1,12 @@
+package dev.architectury.loom.metadata;
+
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
+import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
+
+public interface ModMetadataFile {
+	@Nullable String getAccessWidener();
+	List<InterfaceInjectionProcessor.InjectedInterface> getInjectedInterfaces(@Nullable String modId);
+}

--- a/src/main/java/dev/architectury/loom/metadata/QuiltModJson.java
+++ b/src/main/java/dev/architectury/loom/metadata/QuiltModJson.java
@@ -79,7 +79,17 @@ public final class QuiltModJson implements ModMetadataFile {
 		}
 
 		// Quilt injected interfaces have the same format as architectury.common.json
-		return ArchitecturyCommonJson.getInjectedInterfaces(json.getAsJsonObject("quilt_loom"), modId);
+		if (json.has("quilt_loom")) {
+			JsonElement quiltLoom = json.get("quilt_loom");
+
+			if (quiltLoom.isJsonObject()) {
+				return ArchitecturyCommonJson.getInjectedInterfaces(json.getAsJsonObject("quilt_loom"), modId);
+			} else {
+				LOGGER.warn("Unexpected type for 'quilt_loom' in quilt.mod.json: {}", quiltLoom.getClass());
+			}
+		}
+
+		return List.of();
 	}
 
 	public List<String> getMixinConfigs() {

--- a/src/main/java/dev/architectury/loom/metadata/QuiltModJson.java
+++ b/src/main/java/dev/architectury/loom/metadata/QuiltModJson.java
@@ -1,0 +1,110 @@
+package dev.architectury.loom.metadata;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.fabricmc.loom.LoomGradlePlugin;
+import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
+
+public final class QuiltModJson implements ModMetadataFile {
+	private static final Logger LOGGER = LoggerFactory.getLogger(QuiltModJson.class);
+	private static final String ACCESS_WIDENER_KEY = "access_widener";
+	private static final String MIXIN_KEY = "mixin";
+
+	private final JsonObject json;
+
+	private QuiltModJson(JsonObject json) {
+		this.json = Objects.requireNonNull(json, "json");
+	}
+
+	public static QuiltModJson of(byte[] utf8) {
+		return of(new String(utf8, StandardCharsets.UTF_8));
+	}
+
+	public static QuiltModJson of(String text) {
+		return of(LoomGradlePlugin.GSON.fromJson(text, JsonObject.class));
+	}
+
+	public static QuiltModJson of(Path path) throws IOException {
+		return of(Files.readString(path, StandardCharsets.UTF_8));
+	}
+
+	public static QuiltModJson of(File file) throws IOException {
+		return of(file.toPath());
+	}
+
+	public static QuiltModJson of(JsonObject json) {
+		return new QuiltModJson(json);
+	}
+
+	@Override
+	public @Nullable String getAccessWidener() {
+		if (json.has(ACCESS_WIDENER_KEY)) {
+			if (json.get(ACCESS_WIDENER_KEY).isJsonArray()) {
+				JsonArray array = json.get(ACCESS_WIDENER_KEY).getAsJsonArray();
+
+				// TODO (1.1): Support multiple access wideners in Quilt mods
+				if (array.size() != 1) {
+					throw new UnsupportedOperationException("Loom does not support multiple access wideners in one mod!");
+				}
+
+				return array.get(0).getAsString();
+			} else {
+				return json.get(ACCESS_WIDENER_KEY).getAsString();
+			}
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public List<InterfaceInjectionProcessor.InjectedInterface> getInjectedInterfaces(@Nullable String modId) {
+		try {
+			modId = Objects.requireNonNullElseGet(modId, () -> json.getAsJsonObject("quilt_loader").get("id").getAsString());
+		} catch (NullPointerException e) {
+			throw new IllegalArgumentException("Could not determine mod ID for Quilt mod and no fallback provided");
+		}
+
+		// Quilt injected interfaces have the same format as architectury.common.json
+		return ArchitecturyCommonJson.getInjectedInterfaces(json.getAsJsonObject("quilt_loom"), modId);
+	}
+
+	public List<String> getMixinConfigs() {
+		// RFC 0002: The `mixin` field:
+		//   Type: Array/String
+		//   Required: False
+
+		if (json.has(MIXIN_KEY)) {
+			JsonElement mixin = json.get(MIXIN_KEY);
+
+			if (mixin.isJsonPrimitive()) {
+				return List.of(mixin.getAsString());
+			} else if (mixin.isJsonArray()) {
+				List<String> mixinConfigs = new ArrayList<>();
+
+				for (JsonElement child : mixin.getAsJsonArray()) {
+					mixinConfigs.add(child.getAsString());
+				}
+
+				return mixinConfigs;
+			} else {
+				LOGGER.warn("'mixin' key in quilt.mod.json is of unexpected type {}", mixin.getClass());
+			}
+		}
+
+		return List.of();
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerFile.java
+++ b/src/main/java/net/fabricmc/loom/configuration/accesswidener/AccessWidenerFile.java
@@ -32,8 +32,9 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import dev.architectury.loom.metadata.ArchitecturyCommonJson;
+import dev.architectury.loom.metadata.QuiltModJson;
 
 import net.fabricmc.loom.util.ZipUtils;
 
@@ -56,7 +57,7 @@ public record AccessWidenerFile(
 
 		if (modJsonBytes == null) {
 			if (ZipUtils.contains(modJarPath, "architectury.common.json")) {
-				String awPath = null;
+				String awPath;
 				byte[] commonJsonBytes;
 
 				try {
@@ -66,13 +67,8 @@ public record AccessWidenerFile(
 				}
 
 				if (commonJsonBytes != null) {
-					JsonObject jsonObject = new Gson().fromJson(new String(commonJsonBytes, StandardCharsets.UTF_8), JsonObject.class);
-
-					if (jsonObject.has("accessWidener")) {
-						awPath = jsonObject.get("accessWidener").getAsString();
-					} else {
-						return null;
-					}
+					awPath = ArchitecturyCommonJson.of(commonJsonBytes).getAccessWidener();
+					if (awPath == null) return null;
 				} else {
 					// ???????????
 					throw new IllegalArgumentException("The architectury.common.json file does not exist.");
@@ -94,7 +90,7 @@ public record AccessWidenerFile(
 			}
 
 			if (ZipUtils.contains(modJarPath, "quilt.mod.json")) {
-				String awPath = null;
+				String awPath;
 				byte[] quiltModBytes;
 
 				try {
@@ -104,23 +100,8 @@ public record AccessWidenerFile(
 				}
 
 				if (quiltModBytes != null) {
-					JsonObject jsonObject = new Gson().fromJson(new String(quiltModBytes, StandardCharsets.UTF_8), JsonObject.class);
-
-					if (jsonObject.has("access_widener")) {
-						if (jsonObject.get("access_widener").isJsonArray()) {
-							JsonArray array = jsonObject.get("access_widener").getAsJsonArray();
-
-							if (array.size() != 1) {
-								throw new UnsupportedOperationException("Loom does not support multiple access wideners in one mod!");
-							}
-
-							awPath = array.get(0).getAsString();
-						} else {
-							awPath = jsonObject.get("access_widener").getAsString();
-						}
-					} else {
-						return null;
-					}
+					awPath = QuiltModJson.of(quiltModBytes).getAccessWidener();
+					if (awPath == null) return null;
 				} else {
 					// ???????????
 					throw new IllegalArgumentException("The quilt.mod.json file does not exist.");

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -24,19 +24,12 @@
 
 package net.fabricmc.loom.task;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Serializable;
-import java.io.UncheckedIOException;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -47,9 +40,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.jar.Attributes;
-import java.util.jar.JarFile;
-import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -59,11 +49,9 @@ import javax.inject.Inject;
 import com.google.common.base.Suppliers;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import dev.architectury.loom.extensions.ModBuildExtensions;
 import dev.architectury.tinyremapper.OutputConsumerPath;
 import dev.architectury.tinyremapper.TinyRemapper;
-import org.cadixdev.at.AccessTransformSet;
-import org.cadixdev.at.io.AccessTransformFormats;
-import org.cadixdev.lorenz.MappingSet;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -79,7 +67,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskDependency;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,16 +87,12 @@ import net.fabricmc.loom.task.service.MappingsService;
 import net.fabricmc.loom.task.service.TinyRemapperService;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.ExceptionUtil;
-import net.fabricmc.loom.util.FileSystemUtil;
-import net.fabricmc.loom.util.LfWriter;
 import net.fabricmc.loom.util.ModPlatform;
 import net.fabricmc.loom.util.ModUtils;
 import net.fabricmc.loom.util.Pair;
 import net.fabricmc.loom.util.SidedClassVisitor;
 import net.fabricmc.loom.util.ZipUtils;
-import net.fabricmc.loom.util.aw2at.Aw2At;
 import net.fabricmc.loom.util.service.UnsafeWorkQueueHelper;
-import net.fabricmc.lorenztiny.TinyMappingsReader;
 
 public abstract class RemapJarTask extends AbstractRemapJarTask {
 	@InputFiles
@@ -273,7 +256,7 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 			}
 
 			if (allMixinConfigs == null && getReadMixinConfigsFromManifest().get()) {
-				allMixinConfigs = readMixinConfigsFromManifest();
+				allMixinConfigs = ModBuildExtensions.readMixinConfigsFromManifest(getInputFile().get().getAsFile());
 			}
 
 			if (allMixinConfigs == null) {
@@ -306,27 +289,6 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 					.toList();
 
 			params.getMixinData().add(new RemapParams.RefmapData(mixinConfigs, refmapName));
-		}
-	}
-
-	private Collection<String> readMixinConfigsFromManifest() {
-		File inputJar = getInputFile().get().getAsFile();
-
-		try (JarFile jar = new JarFile(inputJar)) {
-			@Nullable Manifest manifest = jar.getManifest();
-
-			if (manifest != null) {
-				Attributes attributes = manifest.getMainAttributes();
-				String mixinConfigs = attributes.getValue(Constants.Forge.MIXIN_CONFIGS_MANIFEST_KEY);
-
-				if (mixinConfigs != null) {
-					return Set.of(mixinConfigs.split(","));
-				}
-			}
-
-			return Set.of();
-		} catch (IOException e) {
-			throw new UncheckedIOException("Could not read mixin configs from input jar", e);
 		}
 	}
 
@@ -381,7 +343,7 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 
 				addRefmaps();
 				addNestedJars();
-				convertAwToAt();
+				ModBuildExtensions.convertAwToAt(getParameters().getAtAccessWideners(), outputFile, getParameters().getMappingBuildServiceUuid());
 
 				if (getParameters().getPlatform().get() != ModPlatform.FORGE) {
 					modifyJarManifest();
@@ -453,55 +415,6 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 
 			// Finally, replace the output with the remaped aw
 			ZipUtils.replace(outputFile, accessWidenerFile.path(), remapped);
-		}
-
-		private void convertAwToAt() throws IOException {
-			if (!this.getParameters().getAtAccessWideners().isPresent()) {
-				return;
-			}
-
-			Set<String> atAccessWideners = this.getParameters().getAtAccessWideners().get();
-
-			if (atAccessWideners.isEmpty()) {
-				return;
-			}
-
-			AccessTransformSet at = AccessTransformSet.create();
-			File jar = outputFile.toFile();
-
-			try (FileSystemUtil.Delegate fileSystem = FileSystemUtil.getJarFileSystem(jar, false)) {
-				FileSystem fs = fileSystem.get();
-				Path atPath = fs.getPath(Constants.Forge.ACCESS_TRANSFORMER_PATH);
-
-				if (Files.exists(atPath)) {
-					throw new FileAlreadyExistsException("Jar " + jar + " already contains an access transformer - cannot convert AWs!");
-				}
-
-				for (String aw : atAccessWideners) {
-					Path awPath = fs.getPath(aw);
-
-					if (Files.notExists(awPath)) {
-						throw new NoSuchFileException("Could not find AW '" + aw + "' to convert into AT!");
-					}
-
-					try (BufferedReader reader = Files.newBufferedReader(awPath, StandardCharsets.UTF_8)) {
-						at.merge(Aw2At.toAccessTransformSet(reader));
-					}
-
-					Files.delete(awPath);
-				}
-
-				MappingsService service = UnsafeWorkQueueHelper.get(getParameters().getMappingBuildServiceUuid(), MappingsService.class);
-
-				try (TinyMappingsReader reader = new TinyMappingsReader(service.getMemoryMappingTree(), service.getFromNamespace(), service.getToNamespace())) {
-					MappingSet mappingSet = reader.read();
-					at = at.remap(mappingSet);
-				}
-
-				try (Writer writer = new LfWriter(Files.newBufferedWriter(atPath))) {
-					AccessTransformFormats.FML.write(writer, at);
-				}
-			}
 		}
 
 		private byte[] remapAccessWidener(byte[] input) {

--- a/src/test/groovy/net/fabricmc/loom/test/unit/architectury/ArchitecturyCommonJsonTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/architectury/ArchitecturyCommonJsonTest.groovy
@@ -24,10 +24,66 @@
 
 package net.fabricmc.loom.test.unit.architectury
 
+import com.google.gson.JsonObject
 import dev.architectury.loom.metadata.ArchitecturyCommonJson
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
 
 class ArchitecturyCommonJsonTest extends Specification {
+    private static final String OF_TEST_INPUT = '{"accessWidener":"foo.accesswidener"}'
+
+    @TempDir
+    Path tempDir
+
+    def "create from byte[]"() {
+        given:
+            def bytes = OF_TEST_INPUT.getBytes(StandardCharsets.UTF_8)
+        when:
+            def acj = ArchitecturyCommonJson.of(bytes)
+        then:
+            acj.accessWidener == 'foo.accesswidener'
+    }
+
+    def "create from String"() {
+        when:
+            def acj = ArchitecturyCommonJson.of(OF_TEST_INPUT)
+        then:
+            acj.accessWidener == 'foo.accesswidener'
+    }
+
+    def "create from File"() {
+        given:
+            def file = new File(tempDir.toFile(), 'architectury.common.json')
+            file.text = OF_TEST_INPUT
+        when:
+            def acj = ArchitecturyCommonJson.of(file)
+        then:
+            acj.accessWidener == 'foo.accesswidener'
+    }
+
+    def "create from Path"() {
+        given:
+            def path = tempDir.resolve('architectury.common.json')
+            path.text = OF_TEST_INPUT
+        when:
+            def acj = ArchitecturyCommonJson.of(path)
+        then:
+            acj.accessWidener == 'foo.accesswidener'
+    }
+
+    def "create from JsonObject"() {
+        given:
+            def json = new JsonObject()
+            json.addProperty('accessWidener', 'foo.accesswidener')
+        when:
+            def acj = ArchitecturyCommonJson.of(json)
+        then:
+            acj.accessWidener == 'foo.accesswidener'
+    }
+
     def "read access widener"() {
         given:
             def acj = ArchitecturyCommonJson.of(jsonText)

--- a/src/test/groovy/net/fabricmc/loom/test/unit/architectury/ArchitecturyCommonJsonTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/architectury/ArchitecturyCommonJsonTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.architectury
+
+import dev.architectury.loom.metadata.ArchitecturyCommonJson
+import spock.lang.Specification
+
+class ArchitecturyCommonJsonTest extends Specification {
+    def "read access widener"() {
+        given:
+            def acj = ArchitecturyCommonJson.of(jsonText)
+        when:
+            def accessWidenerName = acj.accessWidener
+        then:
+            accessWidenerName == expectedAw
+        where:
+            jsonText                                | expectedAw
+            '{}'                                    | null
+            '{"accessWidener":"foo.accesswidener"}' | 'foo.accesswidener'
+    }
+
+    def "read injected interfaces"() {
+        given:
+            def acj = ArchitecturyCommonJson.of(jsonText)
+        when:
+            def injectedInterfaces = acj.getInjectedInterfaces('foo')
+            Map<String, List<String>> itfMap = [:]
+            for (def entry : injectedInterfaces) {
+                itfMap.computeIfAbsent(entry.className()) { [] }.add(entry.ifaceName())
+            }
+        then:
+            itfMap == expected
+        where:
+            jsonText | expected
+            '{}' | [:]
+            '{"injected_interfaces":{"target/class/Here":["my/Interface","another/Itf"]}}' | ['target/class/Here': ['my/Interface', 'another/Itf']]
+    }
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/architectury/QuiltModJsonTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/architectury/QuiltModJsonTest.groovy
@@ -58,4 +58,18 @@ class QuiltModJsonTest extends Specification {
             '{}' | [:]
             '{"quilt_loom":{"injected_interfaces":{"target/class/Here":["my/Interface","another/Itf"]}}}' | ['target/class/Here': ['my/Interface', 'another/Itf']]
     }
+
+    def "read mixin configs"() {
+        given:
+            def qmj = QuiltModJson.of(jsonText)
+        when:
+            def mixinConfigs = qmj.mixinConfigs
+        then:
+            mixinConfigs == expected
+        where:
+            jsonText | expected
+            '{}' | []
+            '{"mixin":"foo.mixins.json"}' | ['foo.mixins.json']
+            '{"mixin":["foo.mixins.json","bar.mixins.json"]}' | ['foo.mixins.json', 'bar.mixins.json']
+    }
 }

--- a/src/test/groovy/net/fabricmc/loom/test/unit/architectury/QuiltModJsonTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/architectury/QuiltModJsonTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2023 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.unit.architectury
+
+import dev.architectury.loom.metadata.QuiltModJson
+import spock.lang.Specification
+
+class QuiltModJsonTest extends Specification {
+    def "read access widener"() {
+        given:
+            def qmj = QuiltModJson.of(jsonText)
+        when:
+            def accessWidenerName = qmj.accessWidener
+        then:
+            accessWidenerName == expectedAw
+        where:
+            jsonText                                   | expectedAw
+            '{}'                                       | null
+            '{"access_widener":"foo.accesswidener"}'   | 'foo.accesswidener'
+            '{"access_widener":["bar.accesswidener"]}' | 'bar.accesswidener'
+    }
+
+    def "read injected interfaces"() {
+        given:
+            def qmj = QuiltModJson.of(jsonText)
+        when:
+            def injectedInterfaces = qmj.getInjectedInterfaces('foo')
+            Map<String, List<String>> itfMap = [:]
+            for (def entry : injectedInterfaces) {
+                itfMap.computeIfAbsent(entry.className()) { [] }.add(entry.ifaceName())
+            }
+        then:
+            itfMap == expected
+        where:
+            jsonText | expected
+            '{}' | [:]
+            '{"quilt_loom":{"injected_interfaces":{"target/class/Here":["my/Interface","another/Itf"]}}}' | ['target/class/Here': ['my/Interface', 'another/Itf']]
+    }
+}

--- a/src/test/groovy/net/fabricmc/loom/test/unit/quilt/QuiltModJsonTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/quilt/QuiltModJsonTest.groovy
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.test.unit.architectury
+package net.fabricmc.loom.test.unit.quilt
 
 import dev.architectury.loom.metadata.QuiltModJson
 import spock.lang.Specification

--- a/src/test/groovy/net/fabricmc/loom/test/unit/quilt/QuiltModJsonTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/unit/quilt/QuiltModJsonTest.groovy
@@ -24,10 +24,66 @@
 
 package net.fabricmc.loom.test.unit.quilt
 
+import com.google.gson.JsonObject
 import dev.architectury.loom.metadata.QuiltModJson
 import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
 
 class QuiltModJsonTest extends Specification {
+    private static final String OF_TEST_INPUT = '{"access_widener":"foo.accesswidener"}'
+
+    @TempDir
+    Path tempDir
+
+    def "create from byte[]"() {
+        given:
+            def bytes = OF_TEST_INPUT.getBytes(StandardCharsets.UTF_8)
+        when:
+            def qmj = QuiltModJson.of(bytes)
+        then:
+            qmj.accessWidener == 'foo.accesswidener'
+    }
+
+    def "create from String"() {
+        when:
+            def qmj = QuiltModJson.of(OF_TEST_INPUT)
+        then:
+            qmj.accessWidener == 'foo.accesswidener'
+    }
+
+    def "create from File"() {
+        given:
+            def file = new File(tempDir.toFile(), 'quilt.mod.json')
+            file.text = OF_TEST_INPUT
+        when:
+            def qmj = QuiltModJson.of(file)
+        then:
+            qmj.accessWidener == 'foo.accesswidener'
+    }
+
+    def "create from Path"() {
+        given:
+            def path = tempDir.resolve('quilt.mod.json')
+            path.text = OF_TEST_INPUT
+        when:
+            def qmj = QuiltModJson.of(path)
+        then:
+            qmj.accessWidener == 'foo.accesswidener'
+    }
+
+    def "create from JsonObject"() {
+        given:
+            def json = new JsonObject()
+            json.addProperty('access_widener', 'foo.accesswidener')
+        when:
+            def qmj = QuiltModJson.of(json)
+        then:
+            qmj.accessWidener == 'foo.accesswidener'
+    }
+
     def "read access widener"() {
         given:
             def qmj = QuiltModJson.of(jsonText)


### PR DESCRIPTION
This is to clean up the code as well as reduce merge conflicts.