### PR TITLE
Clean up SRG mapping trees and TinyRemapperHelper

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -55,7 +55,6 @@ import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.build.IntermediaryNamespaces;
 import net.fabricmc.loom.configuration.mods.dependency.ModDependency;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
-import net.fabricmc.loom.configuration.providers.mappings.TinyMappingsService;
 import net.fabricmc.loom.task.RemapJarTask;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.LoggerFilter;
@@ -160,8 +159,8 @@ public class ModProcessor {
 
 		Stopwatch stopwatch = Stopwatch.createStarted();
 
-		TinyMappingsService mappingsService = mappingConfiguration.getMappingsService(serviceManager);
-		MemoryMappingTree mappings = (fromM.equals("srg") || toM.equals("srg")) && extension.isForge() ? mappingsService.getMappingTreeWithSrg() : mappingsService.getMappingTree();
+		boolean srg = (fromM.equals("srg") || toM.equals("srg")) && extension.isForge();
+		MemoryMappingTree mappings = mappingConfiguration.getMappingsService(serviceManager, srg).getMappingTree();
 		LoggerFilter.replaceSystemOut();
 		TinyRemapper.Builder builder = TinyRemapper.newRemapper()
 				.logger(project.getLogger()::lifecycle)

--- a/src/main/java/net/fabricmc/loom/configuration/processors/ProcessorContextImpl.java
+++ b/src/main/java/net/fabricmc/loom/configuration/processors/ProcessorContextImpl.java
@@ -64,6 +64,6 @@ public record ProcessorContextImpl(ConfigContext configContext, MinecraftJar min
 	@Override
 	public MemoryMappingTree getMappings() {
 		LoomGradleExtension extension = LoomGradleExtension.get(configContext().project());
-		return extension.getMappingConfiguration().getMappingsService(configContext().serviceManager()).getMappingTree();
+		return extension.getMappingConfiguration().getMappingsService(configContext().serviceManager(), extension.isForge()).getMappingTree();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
@@ -221,8 +221,8 @@ public class MinecraftPatchedProvider {
 
 	private TinyRemapper buildRemapper(SharedServiceManager serviceManager, Path input) throws IOException {
 		Path[] libraries = TinyRemapperHelper.getMinecraftDependencies(project);
-		TinyMappingsService mappingsService = getExtension().getMappingConfiguration().getMappingsService(serviceManager);
-		MemoryMappingTree mappingsWithSrg = mappingsService.getMappingTreeWithSrg();
+		TinyMappingsService mappingsService = getExtension().getMappingConfiguration().getMappingsService(serviceManager, true);
+		MemoryMappingTree mappingsWithSrg = mappingsService.getMappingTree();
 
 		TinyRemapper remapper = TinyRemapper.newRemapper()
 				.logger(logger::lifecycle)

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -155,7 +155,23 @@ public class MappingConfiguration {
 	}
 
 	public TinyMappingsService getMappingsService(SharedServiceManager serviceManager) {
-		return TinyMappingsService.create(serviceManager, Objects.requireNonNull(tinyMappings), Objects.requireNonNull(tinyMappingsWithSrg));
+		return getMappingsService(serviceManager, false);
+	}
+
+	public TinyMappingsService getMappingsService(SharedServiceManager serviceManager, boolean withSrg) {
+		final Path tinyMappings;
+
+		if (withSrg) {
+			if (Files.notExists(this.tinyMappingsWithSrg)) {
+				throw new UnsupportedOperationException("Cannot get mappings service with SRG mappings without SRG enabled!");
+			}
+
+			tinyMappings = this.tinyMappingsWithSrg;
+		} else {
+			tinyMappings = this.tinyMappings;
+		}
+
+		return TinyMappingsService.create(serviceManager, Objects.requireNonNull(tinyMappings));
 	}
 
 	protected void setup(Project project, SharedServiceManager serviceManager, MinecraftProvider minecraftProvider, Path inputJar) throws IOException {
@@ -213,8 +229,8 @@ public class MappingConfiguration {
 
 			if (Files.notExists(srgToNamedSrg) || extension.refreshDeps()) {
 				try (var serviceManager = new ScopedSharedServiceManager()) {
-					TinyMappingsService mappingsService = getMappingsService(serviceManager);
-					SrgNamedWriter.writeTo(project.getLogger(), srgToNamedSrg, mappingsService.getMappingTreeWithSrg(), "srg", "named");
+					TinyMappingsService mappingsService = getMappingsService(serviceManager, true);
+					SrgNamedWriter.writeTo(project.getLogger(), srgToNamedSrg, mappingsService.getMappingTree(), "srg", "named");
 				}
 			}
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/TinyMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/TinyMappingsService.java
@@ -27,9 +27,6 @@ package net.fabricmc.loom.configuration.providers.mappings;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
-import java.util.function.Supplier;
-
-import com.google.common.base.Suppliers;
 
 import net.fabricmc.loom.util.service.SharedService;
 import net.fabricmc.loom.util.service.SharedServiceManager;
@@ -38,36 +35,21 @@ import net.fabricmc.mappingio.tree.MemoryMappingTree;
 
 public final class TinyMappingsService implements SharedService {
 	private final MemoryMappingTree mappingTree;
-	private final Supplier<MemoryMappingTree> mappingTreeWithSrg;
 
-	public TinyMappingsService(Path tinyMappings, Path tinyMappingsWithSrg) {
+	public TinyMappingsService(Path tinyMappings) {
 		try {
 			this.mappingTree = new MemoryMappingTree();
 			MappingReader.read(tinyMappings, mappingTree);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Failed to read mappings", e);
 		}
-
-		this.mappingTreeWithSrg = Suppliers.memoize(() -> {
-			try {
-				MemoryMappingTree tree = new MemoryMappingTree();
-				MappingReader.read(tinyMappingsWithSrg, tree);
-				return tree;
-			} catch (IOException e) {
-				throw new UncheckedIOException("Failed to read mappings", e);
-			}
-		});
 	}
 
-	public static synchronized TinyMappingsService create(SharedServiceManager serviceManager, Path tinyMappings, Path tinyMappingsWithSrg) {
-		return serviceManager.getOrCreateService("TinyMappingsService:" + tinyMappings.toAbsolutePath(), () -> new TinyMappingsService(tinyMappings, tinyMappingsWithSrg));
+	public static synchronized TinyMappingsService create(SharedServiceManager serviceManager, Path tinyMappings) {
+		return serviceManager.getOrCreateService("TinyMappingsService:" + tinyMappings.toAbsolutePath(), () -> new TinyMappingsService(tinyMappings));
 	}
 
 	public MemoryMappingTree getMappingTree() {
 		return mappingTree;
-	}
-
-	public MemoryMappingTree getMappingTreeWithSrg() {
-		return mappingTreeWithSrg.get();
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
@@ -201,8 +201,8 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 
 		if (extension.isForgeAndOfficial()) {
 			try (var serviceManager = new ScopedSharedServiceManager()) {
-				TinyMappingsService mappingsService = extension.getMappingConfiguration().getMappingsService(serviceManager);
-				MemoryMappingTree mappingsWithSrg = mappingsService.getMappingTreeWithSrg();
+				TinyMappingsService mappingsService = extension.getMappingConfiguration().getMappingsService(serviceManager, true);
+				MemoryMappingTree mappingsWithSrg = mappingsService.getMappingTree();
 				RemapObjectHolderVisitor.remapObjectHolder(remappedJars.outputJar().getPath(), "net.minecraftforge.registries.ObjectHolderRegistry", mappingsWithSrg, "srg", "named");
 			}
 		}

--- a/src/main/java/net/fabricmc/loom/configuration/sources/ForgeSourcesRemapper.java
+++ b/src/main/java/net/fabricmc/loom/configuration/sources/ForgeSourcesRemapper.java
@@ -202,8 +202,8 @@ public class ForgeSourcesRemapper {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 		Mercury mercury = SourceRemapper.createMercuryWithClassPath(project, false);
 
-		TinyMappingsService mappingsService = extension.getMappingConfiguration().getMappingsService(serviceManager);
-		MappingSet mappings = new TinyMappingsReader(mappingsService.getMappingTreeWithSrg(), "srg", "named").read();
+		TinyMappingsService mappingsService = extension.getMappingConfiguration().getMappingsService(serviceManager, true);
+		MappingSet mappings = new TinyMappingsReader(mappingsService.getMappingTree(), "srg", "named").read();
 
 		for (Map.Entry<String, String> entry : TinyRemapperHelper.JSR_TO_JETBRAINS.entrySet()) {
 			mappings.getOrCreateClassMapping(entry.getKey()).setDeobfuscatedName(entry.getValue());

--- a/src/main/java/net/fabricmc/loom/task/service/LorenzMappingService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/LorenzMappingService.java
@@ -32,7 +32,6 @@ import org.cadixdev.lorenz.MappingSet;
 
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
-import net.fabricmc.loom.configuration.providers.mappings.TinyMappingsService;
 import net.fabricmc.loom.util.service.SharedService;
 import net.fabricmc.loom.util.service.SharedServiceManager;
 import net.fabricmc.lorenztiny.TinyMappingsReader;
@@ -47,8 +46,8 @@ public final class LorenzMappingService implements SharedService {
 
 	public static synchronized LorenzMappingService create(SharedServiceManager sharedServiceManager, MappingConfiguration mappingConfiguration, MappingsNamespace from, MappingsNamespace to) {
 		return sharedServiceManager.getOrCreateService(mappingConfiguration.getBuildServiceName("LorenzMappingService", from.toString(), to.toString()), () -> {
-			TinyMappingsService mappingsService = mappingConfiguration.getMappingsService(sharedServiceManager);
-			MemoryMappingTree m = (from == MappingsNamespace.SRG || to == MappingsNamespace.SRG) ? mappingsService.getMappingTreeWithSrg() : mappingsService.getMappingTree();
+			boolean srg = (from == MappingsNamespace.SRG || to == MappingsNamespace.SRG);
+			MemoryMappingTree m = mappingConfiguration.getMappingsService(sharedServiceManager, srg).getMappingTree();
 
 			try {
 				try (var reader = new TinyMappingsReader(m, from.toString(), to.toString())) {

--- a/src/main/java/net/fabricmc/loom/util/TinyRemapperHelper.java
+++ b/src/main/java/net/fabricmc/loom/util/TinyRemapperHelper.java
@@ -27,25 +27,18 @@ package net.fabricmc.loom.util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import dev.architectury.tinyremapper.IMappingProvider;
 import dev.architectury.tinyremapper.TinyRemapper;
-import org.apache.commons.lang3.mutable.Mutable;
-import org.apache.commons.lang3.mutable.MutableObject;
-import org.apache.commons.lang3.tuple.Triple;
 import org.gradle.api.Project;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
-import net.fabricmc.loom.configuration.providers.mappings.TinyMappingsService;
 import net.fabricmc.loom.util.service.SharedServiceManager;
 import net.fabricmc.loom.util.srg.InnerClassRemapper;
 import net.fabricmc.mappingio.MappingReader;
@@ -77,64 +70,44 @@ public final class TinyRemapperHelper {
 
 	public static TinyRemapper getTinyRemapper(Project project, SharedServiceManager serviceManager, String fromM, String toM, boolean fixRecords, Consumer<TinyRemapper.Builder> builderConsumer, Set<String> fromClassNames) throws IOException {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
+		boolean srg = (fromM.equals(MappingsNamespace.SRG.toString()) || toM.equals(MappingsNamespace.SRG.toString())) && extension.isForge();
+		MemoryMappingTree mappingTree = extension.getMappingConfiguration().getMappingsService(serviceManager, srg).getMappingTree();
 
-		TinyRemapper remapper = _getTinyRemapper(project, fixRecords, builderConsumer).getLeft();
-		ImmutableSet.Builder<IMappingProvider> providers = ImmutableSet.builder();
-		TinyMappingsService mappingsService = extension.getMappingConfiguration().getMappingsService(serviceManager);
-		providers.add(TinyRemapperHelper.create((fromM.equals("srg") || toM.equals("srg")) && extension.isForge() ? mappingsService.getMappingTreeWithSrg() : mappingsService.getMappingTree(), fromM, toM, true));
-
-		if (extension.isForge()) {
-			if (!fromClassNames.isEmpty()) {
-				providers.add(InnerClassRemapper.of(fromClassNames, mappingsService.getMappingTreeWithSrg(), fromM, toM));
-			}
-		} else {
-			providers.add(out -> TinyRemapperHelper.JSR_TO_JETBRAINS.forEach(out::acceptClass));
+		if (fixRecords && !mappingTree.getSrcNamespace().equals(fromM)) {
+			throw new IllegalStateException("Mappings src namespace must match remap src namespace");
 		}
 
-		remapper.replaceMappings(providers.build());
-		return remapper;
-	}
-
-	public static Triple<TinyRemapper, Mutable<MemoryMappingTree>, List<TinyRemapper.ApplyVisitorProvider>> _getTinyRemapper(Project project, boolean fixRecords, Consumer<TinyRemapper.Builder> builderConsumer) throws IOException {
-		LoomGradleExtension extension = LoomGradleExtension.get(project);
-		Mutable<MemoryMappingTree> mappings = new MutableObject<>();
-		List<TinyRemapper.ApplyVisitorProvider> postApply = new ArrayList<>();
+		int intermediaryNsId = mappingTree.getNamespaceId(MappingsNamespace.INTERMEDIARY.toString());
 
 		TinyRemapper.Builder builder = TinyRemapper.newRemapper()
-				.renameInvalidLocals(true)
 				.logUnknownInvokeDynamic(false)
 				.ignoreConflicts(extension.isForge())
 				.cacheMappings(true)
 				.threads(Runtime.getRuntime().availableProcessors())
 				.logger(project.getLogger()::lifecycle)
-				.rebuildSourceFilenames(true);
+				.withMappings(create(mappingTree, fromM, toM, true))
+				.renameInvalidLocals(true)
+				.rebuildSourceFilenames(true)
+				.invalidLvNamePattern(MC_LV_PATTERN)
+				.inferNameFromSameLvIndex(true)
+				.extraPreApplyVisitor((cls, next) -> {
+					if (fixRecords && !cls.isRecord() && "java/lang/Record".equals(cls.getSuperName())) {
+						return new RecordComponentFixVisitor(next, mappingTree, intermediaryNsId);
+					}
 
-		builder.invalidLvNamePattern(MC_LV_PATTERN);
-		builder.inferNameFromSameLvIndex(true);
-		builder.extraPreApplyVisitor((cls, next) -> {
-			if (fixRecords && !cls.isRecord() && "java/lang/Record".equals(cls.getSuperName()) && mappings.getValue() != null) {
-				return new RecordComponentFixVisitor(next, mappings.getValue(), mappings.getValue().getNamespaceId(MappingsNamespace.INTERMEDIARY.toString()));
+					return next;
+				});
+
+		if (extension.isForge()) {
+			if (!fromClassNames.isEmpty()) {
+				builder.withMappings(InnerClassRemapper.of(fromClassNames, mappingTree, fromM, toM));
 			}
-
-			return next;
-		});
-		builder.extraPostApplyVisitor((trClass, classVisitor) -> {
-			for (TinyRemapper.ApplyVisitorProvider provider : postApply) {
-				classVisitor = provider.insertApplyVisitor(trClass, classVisitor);
-			}
-
-			return classVisitor;
-		});
+		} else {
+			builder.withMappings(out -> TinyRemapperHelper.JSR_TO_JETBRAINS.forEach(out::acceptClass));
+		}
 
 		builderConsumer.accept(builder);
-		return Triple.of(builder.build(), mappings, postApply);
-	}
-
-	public static Triple<TinyRemapper, Mutable<MemoryMappingTree>, List<TinyRemapper.ApplyVisitorProvider>> getTinyRemapper(Project project, boolean fixRecords, Consumer<TinyRemapper.Builder> builderConsumer) throws IOException {
-		Triple<TinyRemapper, Mutable<MemoryMappingTree>, List<TinyRemapper.ApplyVisitorProvider>> remapper = _getTinyRemapper(project, fixRecords, builderConsumer);
-		remapper.getLeft().readClassPath(getMinecraftDependencies(project));
-		remapper.getLeft().prepareClasses();
-		return remapper;
+		return builder.build();
 	}
 
 	public static Path[] getMinecraftDependencies(Project project) {


### PR DESCRIPTION
- Instead of a TinyMappingsService holding two files (normal + srg), each file gets its own tiny mappings service.
- Allow using SRG mappings in MinecraftJarProcessor impls via ProcessorContext.
- Reverts most of our extensive changes to TinyRemapperHelper, they're not necessary anymore.
- Restores a missing mapping namespace check to TinyRemapperHelper.getTinyRemapper.

(PR to let tests run)