### PR TITLE
Use Mixin's own SRG obfuscation service

### DIFF
--- a/src/main/java/dev/architectury/loom/util/AsmInheritanceCompleter.java
+++ b/src/main/java/dev/architectury/loom/util/AsmInheritanceCompleter.java
@@ -1,0 +1,179 @@
+package dev.architectury.loom.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+
+import net.fabricmc.loom.util.FileSystemUtil;
+import net.fabricmc.mappingio.FlatMappingVisitor;
+import net.fabricmc.mappingio.MappingVisitor;
+import net.fabricmc.mappingio.adapter.RegularAsFlatMappingVisitor;
+import net.fabricmc.mappingio.tree.MappingTree;
+
+public final class AsmInheritanceCompleter {
+	public static <T extends MappingTree & MappingVisitor> void complete(T tree, List<Path> classpath) throws IOException {
+		Map<String, ClassEntry> entries = new HashMap<>();
+		Set<String> classesToCheck = tree.getClasses()
+				.stream()
+				.map(MappingTree.ClassMapping::getSrcName)
+				.collect(Collectors.toSet());
+		ClassVisitor visitor = new ClassVisitor(Opcodes.ASM9) {
+			private @Nullable ClassEntry getEntry(String name) {
+				return classesToCheck.contains(name) ? entries.computeIfAbsent(name, ClassEntry::new) : null;
+			}
+
+			@Override
+			public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+				ClassEntry entry = getEntry(name);
+				assert entry != null;
+				entry.addParent(getEntry(superName));
+
+				if (interfaces != null) {
+					for (String itf : interfaces) {
+						entry.addParent(getEntry(itf));
+					}
+				}
+			}
+		};
+
+		try (TreeView view = TreeView.of(classpath)) {
+			for (String className : classesToCheck) {
+				Path path = view.getPath(className + ".class");
+				ClassReader cr = new ClassReader(Files.readAllBytes(path));
+				cr.accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+			}
+		}
+
+		FlatMappingVisitor flat = new RegularAsFlatMappingVisitor(tree);
+
+		for (ClassEntry entry : entries.values()) {
+			MappingTree.ClassMapping c = tree.getClass(entry.name);
+
+			for (MappingTree.MethodMapping method : c.getMethods()) {
+				String name = method.getSrcName();
+				String desc = method.getSrcDesc();
+				String[] dstNames = new String[tree.getDstNamespaces().size()];
+
+				for (int i = 0; i < dstNames.length; i++) {
+					dstNames[i] = method.getDstName(i);
+				}
+
+				Queue<ClassEntry> childQueue = new ArrayDeque<>();
+				Set<String> usedEntries = new HashSet<>();
+
+				for (ClassEntry child : entry.children) {
+					childQueue.offer(child);
+					usedEntries.add(child.name);
+				}
+
+				ClassEntry child;
+
+				while ((child = childQueue.poll()) != null) {
+					flat.visitMethod(child.name, name, desc, dstNames);
+
+					for (ClassEntry grandchild : child.children) {
+						if (usedEntries.add(grandchild.name)) {
+							childQueue.offer(grandchild);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static final class ClassEntry {
+		final String name;
+		final List<ClassEntry> children = new ArrayList<>();
+
+		ClassEntry(String name) {
+			this.name = name;
+		}
+
+		void addParent(@Nullable ClassEntry entry) {
+			if (entry != null) {
+				entry.children.add(this);
+			}
+		}
+	}
+
+	private sealed interface TreeView extends Closeable {
+		Path getPath(String name);
+
+		static TreeView of(Path path) throws IOException {
+			if (Files.isDirectory(path)) {
+				return new RootView(path);
+			}
+
+			return new FileSystemView(FileSystemUtil.getJarFileSystem(path, false));
+		}
+
+		static TreeView of(List<Path> paths) throws IOException {
+			List<TreeView> views = new ArrayList<>(paths.size());
+
+			for (Path path : paths) {
+				views.add(of(path));
+			}
+
+			return new CompositeView(views);
+		}
+
+		record FileSystemView(FileSystemUtil.Delegate fs) implements TreeView {
+			@Override
+			public Path getPath(String name) {
+				return fs.getPath(name);
+			}
+
+			@Override
+			public void close() throws IOException {
+				fs.close();
+			}
+		}
+
+		record RootView(Path root) implements TreeView {
+			@Override
+			public Path getPath(String name) {
+				return root.resolve(name);
+			}
+
+			@Override
+			public void close() throws IOException {
+			}
+		}
+
+		record CompositeView(List<TreeView> views) implements TreeView {
+			@Override
+			public Path getPath(String name) {
+				int i = 0;
+				Path path;
+
+				do {
+					path = views.get(i).getPath(name);
+				} while (i < views.size() && Files.notExists(path));
+
+				return path;
+			}
+
+			@Override
+			public void close() throws IOException {
+				for (TreeView view : views) {
+					view.close();
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/dev/architectury/loom/util/BetterTsrg1Reader.java
+++ b/src/main/java/dev/architectury/loom/util/BetterTsrg1Reader.java
@@ -44,7 +44,7 @@ public final class BetterTsrg1Reader {
 				} else if (parts.length == 3) {
 					flat.visitField(parts[0], parts[1], null, parts[2]);
 				} else if (parts.length == 4) {
-					flat.visitMethod(parts[0], parts[1], parts[3], parts[2]);
+					flat.visitMethod(parts[0], parts[1], parts[2], parts[3]);
 				}
 			}
 		}

--- a/src/main/java/dev/architectury/loom/util/BetterTsrg1Reader.java
+++ b/src/main/java/dev/architectury/loom/util/BetterTsrg1Reader.java
@@ -1,13 +1,13 @@
 package dev.architectury.loom.util;
 
-import net.fabricmc.mappingio.FlatMappingVisitor;
-import net.fabricmc.mappingio.MappingVisitor;
-import net.fabricmc.mappingio.adapter.RegularAsFlatMappingVisitor;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
+
+import net.fabricmc.mappingio.FlatMappingVisitor;
+import net.fabricmc.mappingio.MappingVisitor;
+import net.fabricmc.mappingio.adapter.RegularAsFlatMappingVisitor;
 
 // mapping-io's tsrg reader is awful and doesn't support the flat format that mixin uses
 public final class BetterTsrg1Reader {

--- a/src/main/java/dev/architectury/loom/util/BetterTsrg1Reader.java
+++ b/src/main/java/dev/architectury/loom/util/BetterTsrg1Reader.java
@@ -1,0 +1,52 @@
+package dev.architectury.loom.util;
+
+import net.fabricmc.mappingio.FlatMappingVisitor;
+import net.fabricmc.mappingio.MappingVisitor;
+import net.fabricmc.mappingio.adapter.RegularAsFlatMappingVisitor;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
+// mapping-io's tsrg reader is awful and doesn't support the flat format that mixin uses
+public final class BetterTsrg1Reader {
+	public static void read(Reader reader, MappingVisitor visitor, String from, String to) throws IOException {
+		final FlatMappingVisitor flat = new RegularAsFlatMappingVisitor(visitor);
+		final BufferedReader br = new BufferedReader(reader);
+		String currentClass = null;
+		String line;
+
+		if (flat.visitHeader()) {
+			flat.visitNamespaces(from, List.of(to));
+		}
+
+		if (flat.visitContent()) {
+			while ((line = br.readLine()) != null) {
+				if (line.isEmpty() || line.startsWith("#")) continue;
+
+				if (line.startsWith("\t")) {
+					if (line.startsWith("\t\t")) continue;
+					final String[] parts = line.split(" ");
+
+					if (parts.length == 3) {
+						flat.visitMethod(currentClass, parts[0], parts[1], parts[2]);
+					} else if (parts.length == 2) {
+						flat.visitField(currentClass, parts[0], null, parts[1]);
+					}
+				}
+
+				final String[] parts = line.split(" ");
+
+				if (parts.length == 2) {
+					flat.visitClass(parts[0], parts[1]);
+					currentClass = parts[0];
+				} else if (parts.length == 3) {
+					flat.visitField(parts[0], parts[1], null, parts[2]);
+				} else if (parts.length == 4) {
+					flat.visitMethod(parts[0], parts[1], parts[3], parts[4]);
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/dev/architectury/loom/util/BetterTsrg1Reader.java
+++ b/src/main/java/dev/architectury/loom/util/BetterTsrg1Reader.java
@@ -44,7 +44,7 @@ public final class BetterTsrg1Reader {
 				} else if (parts.length == 3) {
 					flat.visitField(parts[0], parts[1], null, parts[2]);
 				} else if (parts.length == 4) {
-					flat.visitMethod(parts[0], parts[1], parts[3], parts[4]);
+					flat.visitMethod(parts[0], parts[1], parts[3], parts[2]);
 				}
 			}
 		}

--- a/src/main/java/dev/architectury/loom/util/SrgMixinArguments.java
+++ b/src/main/java/dev/architectury/loom/util/SrgMixinArguments.java
@@ -1,0 +1,12 @@
+package dev.architectury.loom.util;
+
+import java.util.Map;
+
+public final class SrgMixinArguments {
+	public static final Map<String, String> DEFAULT_ARGUMENTS = Map.of(
+			// Enable the relevant obfuscation service
+			"mappingTypes", "tsrg"
+	);
+	public static final String REOBF_TSRG_FILE = "reobfTsrgFile";
+	public static final String OUT_TSRG_FILE = "outTsrgFile";
+}

--- a/src/main/java/net/fabricmc/loom/build/IntermediaryNamespaces.java
+++ b/src/main/java/net/fabricmc/loom/build/IntermediaryNamespaces.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2022 FabricMC
+ * Copyright (c) 2022-2023 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,6 @@ package net.fabricmc.loom.build;
 import org.gradle.api.Project;
 
 import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 
 public final class IntermediaryNamespaces {
 	/**
@@ -36,21 +35,5 @@ public final class IntermediaryNamespaces {
 	public static String intermediary(Project project) {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
 		return extension.isForge() ? "srg" : "intermediary";
-	}
-
-	/**
-	 * Potentially replaces the remapping target namespace for mixin refmaps.
-	 *
-	 * <p>All {@linkplain #intermediary(Project) intermediary-like namespaces} are replaced
-	 * by {@code intermediary} since fabric-mixin-compile-extensions only supports intermediary.
-	 * We transform the namespaces in the input mappings, e.g. {@code intermediary} -> {@code yraidemretni} and
-	 * {@code srg} -> {@code intermediary}.
-	 *
-	 * @param project   the project
-	 * @param namespace the original namespace
-	 * @return the correct namespace to use
-	 */
-	public static String replaceMixinIntermediaryNamespace(Project project, String namespace) {
-		return namespace.equals(intermediary(project)) ? MappingsNamespace.INTERMEDIARY.toString() : namespace;
 	}
 }

--- a/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
+++ b/src/main/java/net/fabricmc/loom/build/mixin/AnnotationProcessorInvoker.java
@@ -111,16 +111,16 @@ public abstract class AnnotationProcessorInvoker<T extends Task> {
 					put(Constants.MixinArguments.DEFAULT_OBFUSCATION_ENV, "named:" + loom.getMixin().getRefmapTargetNamespace().get());
 					put(Constants.MixinArguments.QUIET, "true");
 
-					if (loom.shouldGenerateSrgTiny() && loom.getMixin().getRefmapTargetNamespace().get().equals(MappingsNamespace.SRG.toString())) {
+					if (loom.shouldGenerateSrgTiny()) {
 						putAll(SrgMixinArguments.DEFAULT_ARGUMENTS);
 
-						if (loom.isForge()) {
+						if (loom.isForge() && loom.getMixin().getRefmapTargetNamespace().get().equals(MappingsNamespace.SRG.toString())) {
 							put(Constants.MixinArguments.DEFAULT_OBFUSCATION_ENV, "searge");
 						}
 
 						final Path mixinMappingsTsrg = getMixinTsrgMappingsForSourceSet(project, sourceSet);
 						task.getOutputs().file(mixinMappingsTsrg).withPropertyName("mixin-ap-srg-" + sourceSet.getName()).optional();
-						put(SrgMixinArguments.REOBF_TSRG_FILE, loom.getMappingConfiguration().getNamedSrgTsrg(loom).toAbsolutePath().toString());
+						put(SrgMixinArguments.REOBF_TSRG_FILE, loom.getMappingConfiguration().getNamedSrgTsrg(project).toAbsolutePath().toString());
 						put(SrgMixinArguments.OUT_TSRG_FILE, mixinMappingsTsrg.toAbsolutePath().toString());
 					}
 				}};
@@ -201,8 +201,6 @@ public abstract class AnnotationProcessorInvoker<T extends Task> {
 
 		if (!extension.shouldGenerateSrgTiny()) {
 			throw new UnsupportedOperationException("Mixin TSRG mappings are only available if SRG is enabled");
-		} else if (!extension.getMixin().getRefmapTargetNamespace().get().equals(MappingsNamespace.SRG.toString())) {
-			throw new UnsupportedOperationException("Cannot use mixin TSRG mappings when targeting other namespaces");
 		}
 
 		return extension.getFiles().getProjectBuildCache().toPath()

--- a/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
@@ -127,6 +127,9 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 			}
 
 			if (PropertyUtil.getAndFinalize(getExtension().getForge().getUseCustomMixin())) {
+				// TODO: Just use the actual Tiny file instead of a "replaced target" one,
+				//  the runtime can switch to using `srg` as the input namespace instead of `intermediary`.
+				//  Or it could be configurable via another system property.
 				launchConfig.property("mixin.forgeloom.inject.mappings.srg-named", getExtension().getMappingConfiguration().getReplacedTarget(getExtension(), "srg").toAbsolutePath().toString());
 			} else {
 				launchConfig.property("net.minecraftforge.gradle.GradleStart.srg.srg-mcp", getExtension().getMappingConfiguration().srgToNamedSrg.toAbsolutePath().toString());

--- a/src/main/java/net/fabricmc/loom/util/srg/SrgNamedWriter.java
+++ b/src/main/java/net/fabricmc/loom/util/srg/SrgNamedWriter.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.cadixdev.lorenz.io.srg.SrgWriter;
+import org.cadixdev.lorenz.io.srg.tsrg.TSrgWriter;
 import org.gradle.api.logging.Logger;
 
 import net.fabricmc.lorenztiny.TinyMappingsReader;
@@ -39,6 +40,16 @@ public class SrgNamedWriter {
 		Files.deleteIfExists(srgFile);
 
 		try (SrgWriter writer = new SrgWriter(Files.newBufferedWriter(srgFile))) {
+			try (TinyMappingsReader reader = new TinyMappingsReader(mappings, from, to)) {
+				writer.write(reader.read());
+			}
+		}
+	}
+
+	public static void writeTsrgTo(Path srgFile, MappingTree mappings, String from, String to) throws IOException {
+		Files.deleteIfExists(srgFile);
+
+		try (TSrgWriter writer = new TSrgWriter(Files.newBufferedWriter(srgFile))) {
 			try (TinyMappingsReader reader = new TinyMappingsReader(mappings, from, to)) {
 				writer.write(reader.read());
 			}


### PR DESCRIPTION
- [x] Add inherited method names (essentially undo what SrgMerger does to get rid of them)

This removes the need for hacky code with "`yraidemretni`" namespaces and all the mapping file modification.

Probably fixes #105.