### PR TITLE
Fix #136

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
@@ -192,7 +192,7 @@ public abstract class InterfaceInjectionProcessor implements MinecraftJarProcess
 	public record InjectedInterface(String modId, String className, String ifaceName) {
 		public static List<InjectedInterface> fromMod(FabricModJson fabricModJson) {
 			if (fabricModJson instanceof ModMetadataFabricModJson modMetadataFmj) {
-				return modMetadataFmj.getModMetadata().getInjectedInterfaces(modMetadataFmj.getId());
+				return modMetadataFmj.getInjectedInterfaces();
 			}
 
 			final String modId = fabricModJson.getId();

--- a/src/main/java/net/fabricmc/loom/util/fmj/ModMetadataFabricModJson.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/ModMetadataFabricModJson.java
@@ -36,13 +36,11 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import dev.architectury.loom.metadata.JsonBackedModMetadataFile;
 import dev.architectury.loom.metadata.ModMetadataFile;
-
-import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
-
 import org.gradle.api.Project;
 import org.gradle.api.tasks.SourceSet;
 import org.jetbrains.annotations.Nullable;
 
+import net.fabricmc.loom.configuration.ifaceinject.InterfaceInjectionProcessor;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
 
 public final class ModMetadataFabricModJson extends FabricModJson {

--- a/src/main/java/net/fabricmc/loom/util/fmj/ModMetadataFabricModJson.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/ModMetadataFabricModJson.java
@@ -79,7 +79,8 @@ public final class ModMetadataFabricModJson extends FabricModJson {
 
 	@Override
 	public String getId() {
-		return Optional.ofNullable(modMetadata.getId())
+		return Optional.ofNullable(existingFabricJson)
+				.map(FabricModJson::getId)
 				.or(() -> Optional.ofNullable(modMetadata.getId()))
 				.or(this::getIdFromSource)
 				.orElseGet(super::getId);


### PR DESCRIPTION
When a file contains both `fabric.mod.json` and a format supported by `ModMetadataFile` (for example `architectury.common.json`), the file `architectury.common.json` overrides `fabric.mod.json`.

Since the upstream `FabricModJson` system is fundamentally fabric-exclusive, this PR goes over the existing jar/directory with the original detection to find `fabric.mod.json`, and its data take precedence over those supplied by `ModMetadataFile`.

Under this PR,
**Case: A jar with both fabric.mod.json & architectury.common.json (KubeJS)**
modid, mixins, CTs (AWs) are taken from `fabric.mod.json`
Injected Interfaces are taken from both jsons.

I think the diff is a bit big, but should be fine since most of the diffs are modifying existing custom arch code