### PR TITLE
Delete forge mods' jarjar metadata

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ModProcessor.java
@@ -121,6 +121,12 @@ public class ModProcessor {
 	}
 
 	private void stripNestedJars(Path path) {
+		try {
+			ZipUtils.deleteIfExists(path, "META-INF/jarjar/metadata.json");
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to strip nested jars from %s".formatted(path), e);
+		}
+
 		if (!ZipUtils.contains(path, "fabric.mod.json")) {
 			if (ZipUtils.contains(path, "quilt.mod.json")) {
 				// Strip out all contained jar info as we dont want loader to try and load the jars contained in dev.

--- a/src/main/java/net/fabricmc/loom/util/ZipUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipUtils.java
@@ -184,6 +184,12 @@ public class ZipUtils {
 		}
 	}
 
+	public static void deleteIfExists(Path zip, String path) throws IOException {
+		try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(zip, true)) {
+			Files.deleteIfExists(fs.get().getPath(path));
+		}
+	}
+
 	public static int transformString(Path zip, Collection<Pair<String, UnsafeUnaryOperator<String>>> transforms) throws IOException {
 		return transformString(zip, transforms.stream());
 	}

--- a/src/main/java/net/fabricmc/loom/util/ZipUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipUtils.java
@@ -186,7 +186,7 @@ public class ZipUtils {
 
 	public static void deleteIfExists(Path zip, String path) throws IOException {
 		try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(zip, false)) {
-			Files.deleteIfExists(fs.get().getPath(path));
+			Files.deleteIfExists(fs.getPath(path));
 		}
 	}
 

--- a/src/main/java/net/fabricmc/loom/util/ZipUtils.java
+++ b/src/main/java/net/fabricmc/loom/util/ZipUtils.java
@@ -185,7 +185,7 @@ public class ZipUtils {
 	}
 
 	public static void deleteIfExists(Path zip, String path) throws IOException {
-		try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(zip, true)) {
+		try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(zip, false)) {
 			Files.deleteIfExists(fs.get().getPath(path));
 		}
 	}


### PR DESCRIPTION
This should be consistent with how Loom handles Fabric jars with JIJ, prevents artifacts with JIJ mods from crashing in game due to it not being remapped.

This is not tested yet. I will update this comment when it is. 