### PR TITLE
Support newer versions of MinecraftForge 1.20.2.

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeRunTemplate.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeRunTemplate.java
@@ -58,6 +58,9 @@ public record ForgeRunTemplate(
 
 		settings.vmArgs(CollectionUtil.map(jvmArgs, value -> value.resolve(configValueResolver)));
 
+		// Add MOD_CLASSES, this is something that ForgeGradle does
+		env.computeIfAbsent("MOD_CLASSES", $ -> ConfigValue.of("{source_roots}"));
+
 		env.forEach((key, value) -> {
 			String resolved = value.resolve(configValueResolver);
 			settings.getEnvironmentVariables().putIfAbsent(key, resolved);

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeRunTemplate.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeRunTemplate.java
@@ -58,13 +58,13 @@ public record ForgeRunTemplate(
 
 		settings.vmArgs(CollectionUtil.map(jvmArgs, value -> value.resolve(configValueResolver)));
 
-		// Add MOD_CLASSES, this is something that ForgeGradle does
-		env.computeIfAbsent("MOD_CLASSES", $ -> ConfigValue.of("{source_roots}"));
-
 		env.forEach((key, value) -> {
 			String resolved = value.resolve(configValueResolver);
 			settings.getEnvironmentVariables().putIfAbsent(key, resolved);
 		});
+
+		// Add MOD_CLASSES, this is something that ForgeGradle does
+		settings.getEnvironmentVariables().computeIfAbsent("MOD_CLASSES", $ -> ConfigValue.of("{source_roots}").resolve(configValueResolver));
 	}
 
 	public static ForgeRunTemplate fromJson(JsonObject json) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MinecraftPatchedProvider.java
@@ -143,7 +143,7 @@ public class MinecraftPatchedProvider {
 		minecraftPatchedSrgJar = forgeWorkingDir.resolve("minecraft-" + type.id + "-srg-patched.jar");
 		minecraftPatchedSrgAtJar = forgeWorkingDir.resolve("minecraft-" + type.id + "-srg-at-patched.jar");
 		minecraftPatchedJar = forgeWorkingDir.resolve("minecraft-" + type.id + "-patched.jar");
-		minecraftClientExtra = forgeWorkingDir.resolve("forge-client-extra.jar");
+		minecraftClientExtra = forgeWorkingDir.resolve("client-extra.jar");
 	}
 
 	private void cleanAllCache() throws IOException {


### PR DESCRIPTION
Not sure if that's the best place to put the MOD_CLASSES envvar.
Tested working with 48.0.17 and above.

Forge since 48.0.14 tests jars starting with "client-extra", this PR renames that jar, not sure if renaming the forge-client-extra.jar breaks older versions

Side Effect: This invalidates all current Forge projects, so I am not sure if we really want to rename this jar for everyone

![image](https://github.com/architectury/architectury-loom/assets/34910653/04f39afd-0308-4e13-8c5e-8dbf4d869ebc)
