### PR TITLE
Fix Field Migration

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -195,7 +195,6 @@ public class MappingConfiguration {
 
 	public void setupPost(Project project) throws IOException {
 		LoomGradleExtension extension = LoomGradleExtension.get(project);
-		manipulateMappings(project, tinyMappingsJar);
 
 		if (extension.shouldGenerateSrgTiny()) {
 			if (Files.notExists(tinyMappingsWithSrg) || extension.refreshDeps()) {
@@ -206,6 +205,8 @@ public class MappingConfiguration {
 				project.getLogger().info(":merged srg mappings in " + stopwatch.stop());
 			}
 		}
+
+		manipulateMappings(project, tinyMappingsJar);
 	}
 
 	public void applyToProject(Project project, DependencyInfo dependency) throws IOException {


### PR DESCRIPTION
#162 is caused by SrgMerger dropping the migrated fields. The easiest and most reliable way to fix this is to apply the migration to both base and srg tiny, instead of only applying to the base and let SrgMerger merge the mappings.

The fix seems pretty reliable.