### PR TITLE
Skip output remapping for Mojang-mapped NeoForge projects

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/FieldMigratedMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/FieldMigratedMappingConfiguration.java
@@ -69,9 +69,15 @@ public final class FieldMigratedMappingConfiguration extends MappingConfiguratio
 	private Path rawTinyMappings;
 	private Path rawTinyMappingsWithSrg;
 	private Path rawTinyMappingsWithMojang;
+	private final boolean mojangMappedProject;
 
-	public FieldMigratedMappingConfiguration(String mappingsIdentifier, Path mappingsWorkingDir) {
+	public FieldMigratedMappingConfiguration(String mappingsIdentifier, Path mappingsWorkingDir, boolean mojangMappedProject) {
 		super(mappingsIdentifier, mappingsWorkingDir);
+		this.mojangMappedProject = mojangMappedProject;
+	}
+
+	public boolean isMojangMappedProject() {
+		return this.mojangMappedProject;
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsDependency.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/LayeredMappingsDependency.java
@@ -49,6 +49,8 @@ import net.fabricmc.loom.api.mappings.layered.MappingContext;
 import net.fabricmc.loom.api.mappings.layered.MappingLayer;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.configuration.providers.mappings.extras.unpick.UnpickLayer;
+import net.fabricmc.loom.configuration.providers.mappings.mojmap.MojangMappingsSpec;
+import net.fabricmc.loom.configuration.providers.mappings.parchment.ParchmentMappingsSpec;
 import net.fabricmc.loom.configuration.providers.mappings.utils.AddConstructorMappingVisitor;
 import net.fabricmc.loom.util.ZipUtils;
 import net.fabricmc.mappingio.adapter.MappingDstNsReorder;
@@ -185,5 +187,11 @@ public class LayeredMappingsDependency implements SelfResolvingDependency, FileC
 	@Override
 	public FileCollection getFiles() {
 		return project.files(resolve());
+	}
+
+	public boolean isMojangMappings() {
+		return this.layeredMappingSpec.layers().stream()
+				.skip(1) // see LayeredMappingSpecBuilderImpl
+				.allMatch(spec -> spec instanceof MojangMappingsSpec || spec instanceof ParchmentMappingsSpec);
 	}
 }

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -145,11 +145,13 @@ public class MappingConfiguration {
 
 		if (extension.isForgeLike()) {
 			final boolean mojmap;
+
 			if (dependency.getDependency() instanceof LayeredMappingsDependency layered) {
 				mojmap = layered.isMojangMappings();
 			} else {
 				mojmap = false;
 			}
+
 			mappingConfiguration = new FieldMigratedMappingConfiguration(mappingsIdentifier, workingDir, mojmap);
 		} else {
 			mappingConfiguration = new MappingConfiguration(mappingsIdentifier, workingDir);

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -144,7 +144,13 @@ public class MappingConfiguration {
 		MappingConfiguration mappingConfiguration;
 
 		if (extension.isForgeLike()) {
-			mappingConfiguration = new FieldMigratedMappingConfiguration(mappingsIdentifier, workingDir);
+			final boolean mojmap;
+			if (dependency.getDependency() instanceof LayeredMappingsDependency layered) {
+				mojmap = layered.isMojangMappings();
+			} else {
+				mojmap = false;
+			}
+			mappingConfiguration = new FieldMigratedMappingConfiguration(mappingsIdentifier, workingDir, mojmap);
 		} else {
 			mappingConfiguration = new MappingConfiguration(mappingsIdentifier, workingDir);
 		}

--- a/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/AbstractRemapJarTask.java
@@ -66,6 +66,7 @@ import org.jetbrains.annotations.ApiStatus;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
 import net.fabricmc.loom.build.IntermediaryNamespaces;
+import net.fabricmc.loom.configuration.providers.forge.FieldMigratedMappingConfiguration;
 import net.fabricmc.loom.task.service.JarManifestService;
 import net.fabricmc.loom.util.ZipReprocessorUtil;
 import net.fabricmc.loom.util.ZipUtils;
@@ -166,6 +167,15 @@ public abstract class AbstractRemapJarTask extends Jar {
 	}
 
 	protected abstract List<String> getClientOnlyEntries(SourceSet sourceSet);
+
+	@ApiStatus.Internal
+	public boolean shouldSkipRemap(LoomGradleExtension extension) {
+		return extension.isNeoForge()
+				&& extension.getMappingConfiguration() instanceof FieldMigratedMappingConfiguration c
+				&& c.isMojangMappedProject()
+				&& MappingsNamespace.of(this.getSourceNamespace().get()) == MappingsNamespace.NAMED
+				&& MappingsNamespace.of(this.getTargetNamespace().get()) == MappingsNamespace.MOJANG;
+	}
 
 	public interface AbstractRemapParams extends WorkParameters {
 		RegularFileProperty getInputFile();

--- a/src/main/java/net/fabricmc/loom/task/PrepareJarRemapTask.java
+++ b/src/main/java/net/fabricmc/loom/task/PrepareJarRemapTask.java
@@ -73,6 +73,7 @@ public abstract class PrepareJarRemapTask extends AbstractLoomTask {
 	@TaskAction
 	public void run() {
 		final var service = remapJarTask.getTinyRemapperService();
+
 		if (service == null) {
 			return;
 		}

--- a/src/main/java/net/fabricmc/loom/task/PrepareJarRemapTask.java
+++ b/src/main/java/net/fabricmc/loom/task/PrepareJarRemapTask.java
@@ -72,10 +72,15 @@ public abstract class PrepareJarRemapTask extends AbstractLoomTask {
 
 	@TaskAction
 	public void run() {
+		final var service = remapJarTask.getTinyRemapperService();
+		if (service == null) {
+			return;
+		}
+
 		final WorkQueue workQueue = getWorkerExecutor().noIsolation();
 
 		workQueue.submit(ReadInputsAction.class, params -> {
-			params.getTinyRemapperBuildServiceUuid().set(UnsafeWorkQueueHelper.create(remapJarTask.getTinyRemapperService()));
+			params.getTinyRemapperBuildServiceUuid().set(UnsafeWorkQueueHelper.create(service));
 			params.getInputFile().set(getInputFile());
 		});
 	}

--- a/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapJarTask.java
@@ -204,9 +204,11 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 			}
 
 			final var trService = getTinyRemapperService();
+
 			if (trService != null) {
 				params.getTinyRemapperBuildServiceUuid().set(UnsafeWorkQueueHelper.create(trService));
 			}
+
 			params.getRemapClasspath().from(getClasspath());
 			params.getMultiProjectOptimisation().set(getLoomExtension().multiProjectOptimisation());
 
@@ -365,6 +367,7 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 
 		private void prepare() {
 			final Path inputFile = getParameters().getInputFile().getAsFile().get().toPath();
+
 			if (tinyRemapperService != null) {
 				PrepareJarRemapTask.prepare(tinyRemapperService, inputFile);
 			}
@@ -373,6 +376,7 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 		private void remap() throws IOException {
 			Objects.requireNonNull(tinyRemapper);
 			Objects.requireNonNull(tinyRemapperService);
+
 			try (OutputConsumerPath outputConsumer = new OutputConsumerPath.Builder(outputFile).build()) {
 				outputConsumer.addNonClassFiles(inputFile);
 				tinyRemapper.apply(outputConsumer, tinyRemapperService.getOrCreateTag(inputFile));
@@ -430,6 +434,7 @@ public abstract class RemapJarTask extends AbstractRemapJarTask {
 			if (this.tinyRemapper == null) {
 				return input;
 			}
+
 			int version = AccessWidenerReader.readVersion(input);
 
 			AccessWidenerWriter writer = new AccessWidenerWriter(version);

--- a/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapSourcesJarTask.java
@@ -60,6 +60,7 @@ public abstract class RemapSourcesJarTask extends AbstractRemapJarTask {
 	public void run() {
 		submitWork(RemapSourcesAction.class, params -> {
 			final @Nullable var service = SourceRemapperService.create(serviceManagerProvider.get().get(), this);
+
 			if (service != null) {
 				params.getSourcesRemapperServiceUuid().set(UnsafeWorkQueueHelper.create(service));
 			}

--- a/src/main/java/net/fabricmc/loom/task/service/SourceRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceRemapperService.java
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.LoomGradleExtension;
-import net.fabricmc.loom.configuration.providers.forge.FieldMigratedMappingConfiguration;
 import net.fabricmc.loom.task.RemapSourcesJarTask;
 import net.fabricmc.loom.util.DeletingFileVisitor;
 import net.fabricmc.loom.util.FileSystemUtil;
@@ -58,7 +57,7 @@ public final class SourceRemapperService implements SharedService {
 		final String to = task.getTargetNamespace().get();
 		final String from = task.getSourceNamespace().get();
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
-		if (extension.isNeoForge() && extension.getMappingConfiguration() instanceof FieldMigratedMappingConfiguration c && c.isMojangMappedProject()) {
+		if (task.shouldSkipRemap(extension)) {
 			return null;
 		}
 		final String id = extension.getMappingConfiguration().getBuildServiceName("sourceremapper", from, to);

--- a/src/main/java/net/fabricmc/loom/task/service/SourceRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceRemapperService.java
@@ -57,9 +57,11 @@ public final class SourceRemapperService implements SharedService {
 		final String to = task.getTargetNamespace().get();
 		final String from = task.getSourceNamespace().get();
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
+
 		if (task.shouldSkipRemap(extension)) {
 			return null;
 		}
+
 		final String id = extension.getMappingConfiguration().getBuildServiceName("sourceremapper", from, to);
 		final int javaCompileRelease = SourceRemapper.getJavaCompileRelease(project);
 

--- a/src/main/java/net/fabricmc/loom/task/service/SourceRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceRemapperService.java
@@ -37,10 +37,12 @@ import org.cadixdev.mercury.Mercury;
 import org.cadixdev.mercury.remapper.MercuryRemapper;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.configuration.providers.forge.FieldMigratedMappingConfiguration;
 import net.fabricmc.loom.task.RemapSourcesJarTask;
 import net.fabricmc.loom.util.DeletingFileVisitor;
 import net.fabricmc.loom.util.FileSystemUtil;
@@ -51,11 +53,14 @@ import net.fabricmc.loom.util.service.SharedServiceManager;
 import net.fabricmc.lorenztiny.TinyMappingsReader;
 
 public final class SourceRemapperService implements SharedService {
-	public static synchronized SourceRemapperService create(SharedServiceManager serviceManager, RemapSourcesJarTask task) {
+	public static synchronized @Nullable SourceRemapperService create(SharedServiceManager serviceManager, RemapSourcesJarTask task) {
 		final Project project = task.getProject();
 		final String to = task.getTargetNamespace().get();
 		final String from = task.getSourceNamespace().get();
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
+		if (extension.isNeoForge() && extension.getMappingConfiguration() instanceof FieldMigratedMappingConfiguration c && c.isMojangMappedProject()) {
+			return null;
+		}
 		final String id = extension.getMappingConfiguration().getBuildServiceName("sourceremapper", from, to);
 		final int javaCompileRelease = SourceRemapper.getJavaCompileRelease(project);
 

--- a/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
@@ -48,7 +48,6 @@ import org.jetbrains.annotations.Nullable;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.build.IntermediaryNamespaces;
 import net.fabricmc.loom.build.mixin.AnnotationProcessorInvoker;
-import net.fabricmc.loom.configuration.providers.forge.FieldMigratedMappingConfiguration;
 import net.fabricmc.loom.task.AbstractRemapJarTask;
 import net.fabricmc.loom.util.gradle.GradleUtils;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
@@ -64,7 +63,7 @@ public class TinyRemapperService implements SharedService {
 		final String to = remapJarTask.getTargetNamespace().get();
 		final String from = remapJarTask.getSourceNamespace().get();
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
-		if (extension.isNeoForge() && extension.getMappingConfiguration() instanceof FieldMigratedMappingConfiguration c && c.isMojangMappedProject()) {
+		if (remapJarTask.shouldSkipRemap(extension)) {
 			return null;
 		}
 		final boolean legacyMixin = extension.getMixin().getUseLegacyMixinAp().get();

--- a/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
@@ -48,6 +48,7 @@ import org.jetbrains.annotations.Nullable;
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.build.IntermediaryNamespaces;
 import net.fabricmc.loom.build.mixin.AnnotationProcessorInvoker;
+import net.fabricmc.loom.configuration.providers.forge.FieldMigratedMappingConfiguration;
 import net.fabricmc.loom.task.AbstractRemapJarTask;
 import net.fabricmc.loom.util.gradle.GradleUtils;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
@@ -58,11 +59,14 @@ import net.fabricmc.loom.util.service.SharedService;
 import net.fabricmc.loom.util.service.SharedServiceManager;
 
 public class TinyRemapperService implements SharedService {
-	public static synchronized TinyRemapperService getOrCreate(SharedServiceManager serviceManager, AbstractRemapJarTask remapJarTask) {
+	public static synchronized @Nullable TinyRemapperService getOrCreate(SharedServiceManager serviceManager, AbstractRemapJarTask remapJarTask) {
 		final Project project = remapJarTask.getProject();
 		final String to = remapJarTask.getTargetNamespace().get();
 		final String from = remapJarTask.getSourceNamespace().get();
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
+		if (extension.isNeoForge() && extension.getMappingConfiguration() instanceof FieldMigratedMappingConfiguration c && c.isMojangMappedProject()) {
+			return null;
+		}
 		final boolean legacyMixin = extension.getMixin().getUseLegacyMixinAp().get();
 		final @Nullable KotlinClasspathService kotlinClasspathService = KotlinClasspathService.getOrCreateIfRequired(serviceManager, project);
 

--- a/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/TinyRemapperService.java
@@ -63,9 +63,11 @@ public class TinyRemapperService implements SharedService {
 		final String to = remapJarTask.getTargetNamespace().get();
 		final String from = remapJarTask.getSourceNamespace().get();
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
+
 		if (remapJarTask.shouldSkipRemap(extension)) {
 			return null;
 		}
+
 		final boolean legacyMixin = extension.getMixin().getUseLegacyMixinAp().get();
 		final @Nullable KotlinClasspathService kotlinClasspathService = KotlinClasspathService.getOrCreateIfRequired(serviceManager, project);
 


### PR DESCRIPTION
This brings a pretty noticeable improvement for Neo projects using Mojang mappings. For example, the `remapJar` task for one of my Neo projects went from taking 5s to 1s. This still feels a little long, but any improvements there could probably be sent upstream as they wouldn't be arch/neo-specific.

Ideally, we could also skip the remapping of incoming artifacts (without sacrificing things like stripping included jars). But in my opinion, that's not as big of a deal, since dependencies will be remapped much less often than your project output.

The implementation here clearly isn't optimal, but I think it's a reasonable/minimally-invasive stopgap with how NeoForge support currently works.