### PR TITLE
bump mercury to 0.1.4.17

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ tiny-remapper = "1.10.23"
 access-widener = "2.1.0"
 mapping-io = "0.4.2"
 lorenz-tiny = "4.0.2"
-mercury = "0.1.2.15"
+mercury = "0.1.4.17"
 kotlinx-metadata = "0.7.0"
 
 # Plugins


### PR DESCRIPTION
Fixes stacktraces when depending on libs with module or package info files