### PR TITLE
Set both resources and classes directory to the same directory

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/CompileConfiguration.java
@@ -152,6 +152,17 @@ public abstract class CompileConfiguration implements Runnable {
 					}
 				}
 			}
+
+			if (extension.isForge() && extension.getForgeProvider().getVersion().getForgeMajorVersion() >= 49) {
+				// Merge all source set resources and classes into the same directory
+				// This is required for Forge 1.20.3+ to work properly
+				// This is really a hack in itself, thank you Forge
+				getProject().getExtensions().getByType(JavaPluginExtension.class).getSourceSets().forEach(sourceSet -> {
+					var dir = getProject().getLayout().getBuildDirectory().dir("sourcesSets/%s".formatted(sourceSet.getName()));
+					sourceSet.getOutput().setResourcesDir(dir);
+					sourceSet.getJava().getDestinationDirectory().set(dir);
+				});
+			}
 		});
 
 		finalizedBy("idea", "genIdeaWorkspace");

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeProvider.java
@@ -86,6 +86,7 @@ public class ForgeProvider extends DependencyProvider {
 		private final String combined;
 		private final String minecraftVersion;
 		private final String forgeVersion;
+		private final int forgeMajorVersion;
 
 		public ForgeVersion(String combined) {
 			this.combined = combined;
@@ -93,6 +94,7 @@ public class ForgeProvider extends DependencyProvider {
 			if (combined == null) {
 				this.minecraftVersion = "NO_VERSION";
 				this.forgeVersion = "NO_VERSION";
+				this.forgeMajorVersion = -1;
 				return;
 			}
 
@@ -105,6 +107,20 @@ public class ForgeProvider extends DependencyProvider {
 				this.minecraftVersion = "NO_VERSION";
 				this.forgeVersion = combined;
 			}
+
+			int major;
+
+			try {
+				if (this.forgeVersion.contains(".")) {
+					major = Integer.parseInt(this.forgeVersion.substring(0, this.forgeVersion.indexOf('.')));
+				} else {
+					major = Integer.parseInt(this.forgeVersion);
+				}
+			} catch (NumberFormatException e) {
+				major = -1;
+			}
+
+			this.forgeMajorVersion = major;
 		}
 
 		public String getCombined() {
@@ -117,6 +133,10 @@ public class ForgeProvider extends DependencyProvider {
 
 		public String getForgeVersion() {
 			return forgeVersion;
+		}
+
+		public int getForgeMajorVersion() {
+			return forgeMajorVersion;
 		}
 	}
 }


### PR DESCRIPTION
See this giant commit: https://github.com/MinecraftForge/MinecraftForge/commit/6f9f0f0cfacc74d62be39359d773d5dda220ad73

MOD_CLASSES is no longer a thing on Forge (mods are detected automatically properly now), we may deprecate that later.

Forge's MDK has this new code:
![image](https://github.com/architectury/architectury-loom/assets/34910653/a8cf329d-4b9d-4d87-b686-a927e885768b)
