### PR TITLE
Fixed getting incorrect mod info from zip by passing the mod loader

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/AccessWidenerUtils.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/AccessWidenerUtils.java
@@ -62,7 +62,7 @@ public class AccessWidenerUtils {
 			return null;
 		}
 
-		final FabricModJson fabricModJson = FabricModJsonFactory.createFromZip(inputJar);
+		final FabricModJson fabricModJson = FabricModJsonFactory.createFromZip(inputJar, platform);
 		final List<String> classTweakers = List.copyOf(fabricModJson.getClassTweakers().keySet());
 
 		if (classTweakers.isEmpty()) {

--- a/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonFactory.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonFactory.java
@@ -71,24 +71,23 @@ public final class FabricModJsonFactory {
 		};
 	}
 
-	public static FabricModJson createFromZip(Path zipPath) {
+	public static FabricModJson createFromZip(Path zipPath, ModPlatform platform) {
 		try {
-			return create(ZipUtils.unpackGson(zipPath, FABRIC_MOD_JSON, JsonObject.class), new FabricModJsonSource.ZipSource(zipPath));
-		} catch (IOException e) {
-			// Try another mod metadata file if fabric.mod.json wasn't found.
-			try {
+			if (platform == ModPlatform.FABRIC)
+				return create(ZipUtils.unpackGson(zipPath, FABRIC_MOD_JSON, JsonObject.class), new FabricModJsonSource.ZipSource(zipPath));
+			else {
 				@Nullable ModMetadataFile modMetadata = ModMetadataFiles.fromJar(zipPath);
 
 				if (modMetadata != null) {
 					return new ModMetadataFabricModJson(modMetadata, new FabricModJsonSource.ZipSource(zipPath));
 				}
-			} catch (IOException e2) {
-				var unchecked = new UncheckedIOException("Failed to read mod metadata file in zip: " + zipPath, e2);
-				unchecked.addSuppressed(e);
-				throw unchecked;
-			}
 
-			throw new UncheckedIOException("Failed to read fabric.mod.json file in zip: " + zipPath, e);
+				throw null;
+			}
+		} catch (IOException e) {
+			var unchecked = new UncheckedIOException("Failed to read mod metadata file in zip: " + zipPath, e);
+			unchecked.addSuppressed(e);
+			throw unchecked;
 		}
 	}
 


### PR DESCRIPTION
Passed the `platform` valuable (containing which mod loader it is for) to the `FabricModJsonFactory.createFromZip()` function.\
This would fix https://github.com/architectury/architectury-loom/issues/165, due to it no longer defaulting to checking the `fabric.mod.json`, and if that doesn't exist, then checking the `META-INF/mods.toml` as a back-up. Now it uses the info in whatever the `platform` valuable states.