### PR TITLE
Refactor field migration into a more generalized migrator + add metho…

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeMigratedMappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeMigratedMappingConfiguration.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.forge;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+import com.google.common.base.Stopwatch;
+import org.gradle.api.Project;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.configuration.providers.mappings.MappingConfiguration;
+
+public final class ForgeMigratedMappingConfiguration extends MappingConfiguration {
+	private final List<MappingsMigrator> migrators = List.of(new FieldMappingsMigrator(), new MethodInheritanceMappingsMigrator());
+	private Path hashPath;
+	private Path rawTinyMappings;
+	private Path rawTinyMappingsWithSrg;
+	private Path rawTinyMappingsWithMojang;
+	private long hash;
+
+	public ForgeMigratedMappingConfiguration(String mappingsIdentifier, Path mappingsWorkingDir) {
+		super(mappingsIdentifier, mappingsWorkingDir);
+	}
+
+	@Override
+	protected void manipulateMappings(Project project, Path mappingsJar) throws IOException {
+		LoomGradleExtension extension = LoomGradleExtension.get(project);
+		final Path forgeCache = ForgeProvider.getForgeCache(project);
+		Files.createDirectories(forgeCache);
+
+		boolean hasSrg = extension.shouldGenerateSrgTiny();
+		boolean hasMojang = extension.isNeoForge();
+
+		this.hashPath = forgeCache.resolve("mappings-migrated.hash");
+		this.hash = 1;
+
+		this.rawTinyMappings = this.tinyMappings;
+		this.rawTinyMappingsWithSrg = this.tinyMappingsWithSrg;
+		this.rawTinyMappingsWithMojang = this.tinyMappingsWithMojang;
+		Path rawTinyMappingsWithNs = hasSrg ? this.rawTinyMappingsWithSrg : hasMojang ? this.rawTinyMappingsWithMojang : this.rawTinyMappings;
+
+		this.tinyMappings = mappingsWorkingDir().resolve("mappings-migrated.tiny");
+		this.tinyMappingsWithSrg = mappingsWorkingDir().resolve("mappings-srg-migrated.tiny");
+		this.tinyMappingsWithMojang = mappingsWorkingDir().resolve("mappings-mojang-migrated.tiny");
+		Path tinyMappingsWithNs = hasSrg ? this.tinyMappingsWithSrg : hasMojang ? this.tinyMappingsWithMojang : this.tinyMappings;
+
+		for (MappingsMigrator migrator : this.migrators) {
+			hash = hash * 31 + migrator.setup(project, extension.getMinecraftProvider(), forgeCache, rawTinyMappingsWithNs, hasSrg, hasMojang);
+		}
+
+		if (!isOutdated(extension, hasSrg, hasMojang)) {
+			project.getLogger().info(":manipulated {} mappings are up to date", extension.getPlatform().get().id());
+			return;
+		}
+
+		Stopwatch stopwatch = Stopwatch.createStarted();
+		Files.copy(this.rawTinyMappings, this.tinyMappings, StandardCopyOption.REPLACE_EXISTING);
+		Files.copy(rawTinyMappingsWithNs, tinyMappingsWithNs, StandardCopyOption.REPLACE_EXISTING);
+
+		Files.writeString(this.hashPath, Long.toString(this.hash), StandardCharsets.UTF_8);
+
+		for (MappingsMigrator migrator : this.migrators) {
+			Path path = Files.createTempFile("mappings-working", ".tiny");
+			Path pathWithNs = Files.createTempFile("mappings-working-ns", ".tiny");
+			Files.copy(this.tinyMappings, path, StandardCopyOption.REPLACE_EXISTING);
+			Files.copy(tinyMappingsWithNs, pathWithNs, StandardCopyOption.REPLACE_EXISTING);
+
+			List<MappingsMigrator.MappingsEntry> entries = List.of(new MappingsMigrator.MappingsEntry(path), new MappingsMigrator.MappingsEntry(pathWithNs));
+			migrator.migrate(project, entries);
+
+			Files.copy(path, this.tinyMappings, StandardCopyOption.REPLACE_EXISTING);
+			Files.copy(pathWithNs, tinyMappingsWithNs, StandardCopyOption.REPLACE_EXISTING);
+			Files.deleteIfExists(path);
+			Files.deleteIfExists(pathWithNs);
+		}
+
+		project.getLogger().info(":manipulated {} mappings in " + stopwatch.stop(), extension.getPlatform().get().id());
+	}
+
+	private boolean isOutdated(LoomGradleExtension extension, boolean hasSrg, boolean hasMojang) throws IOException {
+		if (extension.refreshDeps()) return true;
+		if (Files.notExists(this.tinyMappings)) return true;
+		if (hasSrg && Files.notExists(this.tinyMappingsWithSrg)) return true;
+		if (hasMojang && Files.notExists(this.tinyMappingsWithMojang)) return true;
+		if (Files.notExists(this.hashPath)) return true;
+		String hashStr = Files.readString(hashPath, StandardCharsets.UTF_8);
+		return !Long.toString(this.hash).equals(hashStr);
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MappingsMigrator.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MappingsMigrator.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.forge;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.gradle.api.Project;
+
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+
+public interface MappingsMigrator {
+	long setup(Project project, MinecraftProvider minecraftProvider, Path cache, Path rawMappings, boolean hasSrg, boolean hasMojang) throws IOException;
+
+	void migrate(Project project, List<MappingsEntry> entries) throws IOException;
+
+	record MappingsEntry(Path path) {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MethodInheritanceMappingsMigrator.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MethodInheritanceMappingsMigrator.java
@@ -1,0 +1,230 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.configuration.providers.forge;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.api.mappings.layered.MappingsNamespace;
+import net.fabricmc.loom.configuration.providers.minecraft.MinecraftProvider;
+import net.fabricmc.loom.util.FileSystemUtil;
+import net.fabricmc.loom.util.Pair;
+import net.fabricmc.mappingio.MappingReader;
+import net.fabricmc.mappingio.adapter.MappingSourceNsSwitch;
+import net.fabricmc.mappingio.format.tiny.Tiny2FileWriter;
+import net.fabricmc.mappingio.tree.MappingTree;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
+
+/**
+ * With some forge patches, methods can inherit methods from a class that is not in the mappings.
+ * This migrator will try to detect all the methods that are inherited from a class that is not in the mappings,
+ * see if there are different names for the same method in the mappings, and remove them.
+ */
+public final class MethodInheritanceMappingsMigrator implements MappingsMigrator {
+	private Set<Pair<String, String>> methodsToRemove;
+
+	@Override
+	public long setup(Project project, MinecraftProvider minecraftProvider, Path cache, Path rawMappings, boolean hasSrg, boolean hasMojang) throws IOException {
+		Path cacheFile = cache.resolve("method-inhertiance-migrator.json");
+
+		if (!minecraftProvider.refreshDeps() && Files.exists(cacheFile)) {
+			try (BufferedReader reader = Files.newBufferedReader(cacheFile)) {
+				List<Pair<String, String>> list = new Gson().fromJson(reader, new TypeToken<List<Pair<String, String>>>() {
+				}.getType());
+				methodsToRemove = new HashSet<>(list);
+			}
+		} else {
+			Files.deleteIfExists(cacheFile);
+			LoomGradleExtension extension = LoomGradleExtension.get(project);
+			Path patchedIntermediateJar = MinecraftPatchedProvider.get(project).getMinecraftPatchedIntermediateJar();
+			List<Path> jars = List.of(patchedIntermediateJar, extension.getForgeUniversalProvider().getForge().toPath(), extension.getForgeUserdevProvider().getUserdevJar().toPath());
+			methodsToRemove = prepareCache(project.getLogger(), rawMappings, jars, hasSrg, hasMojang);
+			Files.writeString(cacheFile, new Gson().toJson(methodsToRemove.stream().sorted(Comparator.comparing(p -> p.left() + "|" + p.right())).toList()), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+		}
+
+		return methodsToRemove.hashCode();
+	}
+
+	@Override
+	public void migrate(Project project, List<MappingsEntry> entries) throws IOException {
+		for (MappingsEntry entry : entries) {
+			MemoryMappingTree mappings = new MemoryMappingTree();
+
+			try (BufferedReader reader = Files.newBufferedReader(entry.path())) {
+				MappingReader.read(reader, mappings);
+			}
+
+			for (MappingTree.ClassMapping classMapping : mappings.getClasses()) {
+				if (classMapping.getMethods().isEmpty()) continue;
+				classMapping.getMethods().removeIf(method -> {
+					return methodsToRemove.contains(new Pair<>(method.getName(MappingsNamespace.INTERMEDIARY.toString()), method.getDesc(MappingsNamespace.INTERMEDIARY.toString())));
+				});
+			}
+
+			try (Writer writer = Files.newBufferedWriter(entry.path(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+				mappings.accept(new Tiny2FileWriter(writer, false));
+			}
+		}
+	}
+
+	private Set<Pair<String, String>> prepareCache(Logger logger, Path rawMappings, List<Path> jars, boolean hasSrg, boolean hasMojang) throws IOException {
+		MemoryMappingTree mappings = new MemoryMappingTree();
+		String patchedNs = hasSrg ? MappingsNamespace.SRG.toString() : MappingsNamespace.MOJANG.toString();
+
+		try (BufferedReader reader = Files.newBufferedReader(rawMappings)) {
+			MappingReader.read(reader, new MappingSourceNsSwitch(mappings, patchedNs));
+		}
+
+		Multimap<String, String> classInheritanceMap = Multimaps.newSetMultimap(new HashMap<>(), LinkedHashSet::new);
+		Set<MethodKey> methods = new HashSet<>();
+		Visitor visitor = new Visitor(Opcodes.ASM9, classInheritanceMap, methods);
+
+		for (Path jar : jars) {
+			try (FileSystemUtil.Delegate system = FileSystemUtil.getJarFileSystem(jar, false)) {
+				for (Path fsPath : (Iterable<? extends Path>) Files.walk(system.get().getPath("/"))::iterator) {
+					if (Files.isRegularFile(fsPath) && fsPath.toString().endsWith(".class")) {
+						new ClassReader(Files.readAllBytes(fsPath)).accept(visitor, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+					}
+				}
+			}
+		}
+
+		// Populate class inheritance
+		Multimap<String, String> newClassInheritanceMap = Multimaps.newSetMultimap(new HashMap<>(), LinkedHashSet::new);
+		classInheritanceMap.asMap().entrySet().stream().map(entry -> {
+			// Collect all super classes, and their super classes, and so on
+			Set<String> allSuperClasses = new HashSet<>();
+
+			for (String superClass : entry.getValue()) {
+				collectSuperClasses(superClass, new HashSet<>(), allSuperClasses, classInheritanceMap);
+			}
+
+			return Map.entry(entry.getKey(), allSuperClasses);
+		})
+		.forEach(e -> newClassInheritanceMap.putAll(e.getKey(), e.getValue()));
+
+		Set<Pair<String, String>> methodsToRemove = new HashSet<>();
+		Multimap<MethodKey, Pair<String, String>> overridenIntermedaries = Multimaps.newSetMultimap(new HashMap<>(), LinkedHashSet::new);
+
+		for (MethodKey method : methods) {
+			// First check if the method is in the mappings, and as a different intermediary name
+			MappingTree.ClassMapping aClass = mappings.getClass(method.className());
+			if (aClass == null) continue;
+			MappingTree.MethodMapping aMethod = aClass.getMethod(method.name(), method.descriptor());
+			if (aMethod == null) continue;
+			String intermediaryName = aMethod.getName(MappingsNamespace.INTERMEDIARY.toString());
+			if (intermediaryName == null || Objects.equals(intermediaryName, method.name())) continue;
+
+			for (String superClass : newClassInheritanceMap.get(method.className())) {
+				if (methods.contains(new MethodKey(superClass, method.name(), method.descriptor()))) {
+					if (mappings.getClass(superClass) == null) {
+						String intermediaryDesc = aMethod.getDesc(MappingsNamespace.INTERMEDIARY.toString());
+						overridenIntermedaries.put(new MethodKey(superClass, method.name(), method.descriptor()), new Pair<>(intermediaryName, intermediaryDesc));
+					}
+				}
+			}
+		}
+
+		for (Map.Entry<MethodKey, Collection<Pair<String, String>>> entry : overridenIntermedaries.asMap().entrySet()) {
+			if (entry.getValue().size() >= 2) {
+				// We should remove these names from the mappings
+				for (Pair<String, String> pair : entry.getValue()) {
+					methodsToRemove.add(pair);
+					logger.info("Removing method {}{} from the mappings", pair.left(), pair.right());
+				}
+
+				break;
+			}
+		}
+
+		return methodsToRemove;
+	}
+
+	private static void collectSuperClasses(String className, Set<String> travelled, Set<String> allSuperClasses, Multimap<String, String> classInheritanceMap) {
+		if (className != null && !className.isEmpty()) {
+			allSuperClasses.add(className);
+
+			for (String superClass : classInheritanceMap.get(className)) {
+				if (travelled.add(superClass)) {
+					collectSuperClasses(superClass, travelled, allSuperClasses, classInheritanceMap);
+				}
+			}
+		}
+	}
+
+	private static class Visitor extends ClassVisitor {
+		private final Multimap<String, String> classInheritanceMap;
+		private final Set<MethodKey> methods;
+		private String lastClass = null;
+
+		Visitor(int api, Multimap<String, String> classInheritanceMap, Set<MethodKey> methods) {
+			super(api);
+			this.classInheritanceMap = classInheritanceMap;
+			this.methods = methods;
+		}
+
+		@Override
+		public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+			this.lastClass = name;
+			this.classInheritanceMap.put(name, superName);
+			this.classInheritanceMap.putAll(name, Arrays.asList(interfaces));
+		}
+
+		@Override
+		public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+			this.methods.add(new MethodKey(this.lastClass, name, descriptor));
+			return super.visitMethod(access, name, descriptor, signature, exceptions);
+		}
+	}
+
+	private record MethodKey(String className, String name, String descriptor) {
+	}
+}

--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/MethodInheritanceMappingsMigrator.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/MethodInheritanceMappingsMigrator.java
@@ -73,7 +73,7 @@ public final class MethodInheritanceMappingsMigrator implements MappingsMigrator
 
 	@Override
 	public long setup(Project project, MinecraftProvider minecraftProvider, Path cache, Path rawMappings, boolean hasSrg, boolean hasMojang) throws IOException {
-		Path cacheFile = cache.resolve("method-inhertiance-migrator.json");
+		Path cacheFile = cache.resolve("method-inheritance-migrator.json");
 
 		if (!minecraftProvider.refreshDeps() && Files.exists(cacheFile)) {
 			try (BufferedReader reader = Files.newBufferedReader(cacheFile)) {

--- a/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/mappings/MappingConfiguration.java
@@ -57,7 +57,7 @@ import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.LoomGradlePlugin;
 import net.fabricmc.loom.api.mappings.layered.MappingContext;
 import net.fabricmc.loom.configuration.DependencyInfo;
-import net.fabricmc.loom.configuration.providers.forge.FieldMigratedMappingConfiguration;
+import net.fabricmc.loom.configuration.providers.forge.ForgeMigratedMappingConfiguration;
 import net.fabricmc.loom.configuration.providers.forge.SrgProvider;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.MappingsMerger;
 import net.fabricmc.loom.configuration.providers.mappings.tiny.TinyJarInfo;
@@ -130,7 +130,7 @@ public class MappingConfiguration {
 		String mappingsIdentifier;
 
 		if (extension.isForgeLike()) {
-			mappingsIdentifier = FieldMigratedMappingConfiguration.createForgeMappingsIdentifier(extension, mappingsName, version, getMappingsClassifier(dependency, jarInfo.v2()), minecraftProvider.minecraftVersion());
+			mappingsIdentifier = createForgeMappingsIdentifier(extension, mappingsName, version, getMappingsClassifier(dependency, jarInfo.v2()), minecraftProvider.minecraftVersion());
 		} else {
 			mappingsIdentifier = createMappingsIdentifier(mappingsName, version, getMappingsClassifier(dependency, jarInfo.v2()), minecraftProvider.minecraftVersion());
 		}
@@ -144,7 +144,7 @@ public class MappingConfiguration {
 		MappingConfiguration mappingConfiguration;
 
 		if (extension.isForgeLike()) {
-			mappingConfiguration = new FieldMigratedMappingConfiguration(mappingsIdentifier, workingDir);
+			mappingConfiguration = new ForgeMigratedMappingConfiguration(mappingsIdentifier, workingDir);
 		} else {
 			mappingConfiguration = new MappingConfiguration(mappingsIdentifier, workingDir);
 		}
@@ -513,6 +513,13 @@ public class MappingConfiguration {
 		//          mappingsName      . mcVersion . version        classifier
 		// Example: net.fabricmc.yarn . 1_16_5    . 1.16.5+build.5 -v2
 		return mappingsName + "." + minecraftVersion.replace(' ', '_').replace('.', '_').replace('-', '_') + "." + version + classifier;
+	}
+
+	protected static String createForgeMappingsIdentifier(LoomGradleExtension extension, String mappingsName, String version, String classifier, String minecraftVersion) {
+		final String base = createMappingsIdentifier(mappingsName, version, classifier, minecraftVersion);
+		final String platform = extension.getPlatform().get().id();
+		final String forgeVersion = extension.getForgeProvider().getVersion().getCombined();
+		return base + "-" + platform + "-" + forgeVersion;
 	}
 
 	public String mappingsIdentifier() {


### PR DESCRIPTION
…d inheritance migrator

Closes https://github.com/architectury/architectury-loom/issues/206

This PR offers a different solution to the conflicting mappings issue, instead of changing the namespaces that Loom remaps from, this PR fixes the mapping by dropping conflicting names.

As with the field migrator fix, the fix does not radioactively change the remapped jar, but requires a complete refresh by the user, but this should be fine considering that there should be no current setups with the corresponding NeoForge versions.

The reason for this method instead is how much Loom relies on the intermediary namespace, and that it might cause issues that are tricky to debug or fix.

The PR currently 1. refactors field migrator that it becomes one of the migrators, 2. add a new method inheritance migrator

While this PR is significantly larger in diff, it is mostly in archloom-specific classes 