### PR TITLE
Remap NeoForge's mixins

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/minecraft/mapped/AbstractMappedMinecraftProvider.java
@@ -60,6 +60,7 @@ import net.fabricmc.loom.util.service.ScopedSharedServiceManager;
 import net.fabricmc.loom.util.srg.InnerClassRemapper;
 import net.fabricmc.loom.util.srg.RemapObjectHolderVisitor;
 import net.fabricmc.mappingio.tree.MemoryMappingTree;
+import net.fabricmc.tinyremapper.extension.mixin.MixinExtension;
 import net.fabricmc.tinyremapper.OutputConsumerPath;
 import net.fabricmc.tinyremapper.TinyRemapper;
 
@@ -211,6 +212,7 @@ public abstract class AbstractMappedMinecraftProvider<M extends MinecraftProvide
 
 		TinyRemapper remapper = TinyRemapperHelper.getTinyRemapper(getProject(), configContext.serviceManager(), fromM, toM, fixRecords, (builder) -> {
 			builder.extraPostApplyVisitor(new SignatureFixerApplyVisitor(remappedSignatures));
+			if (extension.isNeoForge()) builder.extension(new MixinExtension(inputTag -> true));
 			configureRemapper(remappedJars, builder);
 		}, classNames);
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/neoforge/NeoForge1210Test.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/neoforge/NeoForge1210Test.groovy
@@ -24,9 +24,10 @@
 
 package net.fabricmc.loom.test.integration.neoforge
 
-import net.fabricmc.loom.test.util.GradleProjectTestTrait
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
 
 import static net.fabricmc.loom.test.LoomTestConstants.DEFAULT_GRADLE
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS

--- a/src/test/groovy/net/fabricmc/loom/test/integration/neoforge/NeoForge1210Test.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/neoforge/NeoForge1210Test.groovy
@@ -1,0 +1,60 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2024 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration.neoforge
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static net.fabricmc.loom.test.LoomTestConstants.DEFAULT_GRADLE
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class NeoForge1210Test extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "build #mcVersion #neoforgeVersion #mappings #patches"() {
+		if (Integer.valueOf(System.getProperty("java.version").split("\\.")[0]) < 21) {
+			println("This test requires Java 21. Currently you have Java ${System.getProperty("java.version")}.")
+			return
+		}
+
+		setup:
+		def gradle = gradleProject(project: "neoforge/1210", version: DEFAULT_GRADLE)
+		gradle.buildGradle.text = gradle.buildGradle.text.replace('@MCVERSION@', mcVersion)
+				.replace('@NEOFORGEVERSION@', neoforgeVersion)
+				.replace('MAPPINGS', mappings) // Spotless doesn't like the @'s
+				.replace('PATCHES', patches)
+
+		when:
+		def result = gradle.run(task: "build")
+
+		then:
+		result.task(":build").outcome == SUCCESS
+
+		where:
+		mcVersion | neoforgeVersion | mappings | patches
+		'1.21'  | '21.0.77-beta' | 'loom.officialMojangMappings()' | ''
+		'1.21'  | '21.0.77-beta' | "'net.fabricmc:yarn:1.21+build.1:v2'" | "'dev.architectury:yarn-mappings-patch-neoforge:1.21+build.4'"
+	}
+}

--- a/src/test/resources/projects/neoforge/1210/build.gradle
+++ b/src/test/resources/projects/neoforge/1210/build.gradle
@@ -1,0 +1,83 @@
+plugins {
+	id 'dev.architectury.loom'
+	id 'maven-publish'
+}
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
+}
+
+base {
+	archivesName = project.archives_base_name
+}
+
+version = project.mod_version
+group = project.maven_group
+
+def mcVersion = "@MCVERSION@"
+def neoforgeVersion = "@NEOFORGEVERSION@"
+
+repositories {
+	// Add repositories to retrieve artifacts from in here.
+	// You should only use this when depending on other mods because
+	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
+	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
+	// for more information about repositories.
+	maven { url "https://maven.neoforged.net/releases/" }
+}
+
+dependencies {
+	// To change the versions see the gradle.properties file
+	minecraft "com.mojang:minecraft:$mcVersion"
+	if ("MAPPINGS".equals("loom.officialMojangMappings()")) {
+		mappings loom.officialMojangMappings()
+	} else {
+		mappings loom.layered {
+			it.mappings(MAPPINGS)
+			it.mappings(PATCHES)
+		}
+	}
+
+	neoForge "net.neoforged:neoforge:$neoforgeVersion"
+}
+
+tasks.withType(JavaCompile).configureEach {
+	it.options.release = 21
+}
+
+java {
+	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+	// if it is present.
+	// If you remove this line, sources will not be generated.
+	withSourcesJar()
+}
+
+jar {
+	from("LICENSE") {
+		rename { "${it}_${project.archivesBaseName}"}
+	}
+}
+
+// configure the maven publication
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			// add all the jars that should be included when publishing to maven
+			artifact(remapJar) {
+				builtBy remapJar
+			}
+			artifact(sourcesJar) {
+				builtBy remapSourcesJar
+			}
+		}
+	}
+
+	// See https://docs.gradle.org/current/userguide/publishing_maven.html for information on how to set up publishing.
+	repositories {
+		// Add repositories to publish to here.
+		// Notice: This block does NOT have the same function as the block in the top level.
+		// The repositories here will be used for publishing your artifact, not for
+		// retrieving dependencies.
+	}
+}

--- a/src/test/resources/projects/neoforge/1210/gradle.properties
+++ b/src/test/resources/projects/neoforge/1210/gradle.properties
@@ -1,0 +1,11 @@
+# Done to increase the memory available to gradle.
+org.gradle.jvmargs=-Xmx1G
+
+# Mod Properties
+mod_version = 1.0.0
+maven_group = com.example
+archives_base_name = fabric-example-mod
+
+# Dependencies
+# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
+loom.platform = neoforge

--- a/src/test/resources/projects/neoforge/1210/settings.gradle
+++ b/src/test/resources/projects/neoforge/1210/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "fabric-example-mod"
+


### PR DESCRIPTION
NeoForge has added a few mixins since 21.0.61, which are not accounted for by Architectury Loom, this PR fixes it.