### PR TITLE
Switch to "include" filter on Forge's repo

### DIFF
--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -24,6 +24,8 @@
 
 package net.fabricmc.loom;
 
+import java.util.List;
+
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ArtifactRepositoryContainer;
@@ -40,6 +42,13 @@ import net.fabricmc.loom.extension.LoomFiles;
 import net.fabricmc.loom.util.MirrorUtil;
 
 public class LoomRepositoryPlugin implements Plugin<PluginAware> {
+	private static final List<String> FORGE_GROUPS = List.of(
+			"net.minecraftforge",
+			"cpw.mods",
+			"de.oceanlabs",
+			"org.mcmodlauncher"
+	);
+
 	@Override
 	public void apply(@NotNull PluginAware target) {
 		if (target instanceof Settings settings) {
@@ -95,9 +104,11 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 			repo.setUrl("https://maven.minecraftforge.net/");
 
 			repo.content(descriptor -> {
-				descriptor.excludeGroupByRegex("org\\.eclipse\\.?.*");
-				// Some of these downloads hang and this is already available from central to begin with.
-				descriptor.excludeGroup("org.ow2.asm");
+				// Only include these groups to avoid slowing down/hanging the build,
+				// or downloading incorrect artifacts.
+				for (String group : FORGE_GROUPS) {
+					descriptor.includeGroupAndSubgroups(group);
+				}
 			});
 			repo.metadataSources(sources -> {
 				sources.mavenPom();

--- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
+++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
@@ -46,6 +46,7 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {
 			"net.minecraftforge",
 			"cpw.mods",
 			"de.oceanlabs",
+			"net.jodah",
 			"org.mcmodlauncher"
 	);
 


### PR DESCRIPTION
Fixes #221. The list of groups was determined from Forge's own "project index" as well as just seeing what a standard build downloads from there.

Draft since it needs testing.