### PR TITLE
fix: the mixin config arg is wrong

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
+++ b/src/main/java/net/fabricmc/loom/task/launch/GenerateDLIConfigTask.java
@@ -272,7 +272,7 @@ public abstract class GenerateDLIConfigTask extends AbstractLoomTask {
 
 				if (!mixinConfigs.isEmpty()) {
 					for (String config : mixinConfigs) {
-						launchConfig.argument("-mixin.config");
+						launchConfig.argument("--mixin.config");
 						launchConfig.argument(config);
 					}
 				}


### PR DESCRIPTION
Causing `Exception in thread "main" joptsimple.OptionArgumentConversionException: Cannot parse argument 'ixin.config' of option minecraftJar`