### PR TITLE
fix: use NullOutputStream.NULL_OUTPUT_STREAM rather than NullOutputStream.INSTANCE

### DIFF
--- a/src/main/java/dev/architectury/loom/forge/tool/ForgeToolExecutor.java
+++ b/src/main/java/dev/architectury/loom/forge/tool/ForgeToolExecutor.java
@@ -77,13 +77,13 @@ public abstract class ForgeToolExecutor {
 			if (settings.getShowVerboseStdout().get()) {
 				spec.setStandardOutput(System.out);
 			} else {
-				spec.setStandardOutput(NullOutputStream.INSTANCE);
+				spec.setStandardOutput(NullOutputStream.NULL_OUTPUT_STREAM);
 			}
 
 			if (settings.getShowVerboseStderr().get()) {
 				spec.setErrorOutput(System.err);
 			} else {
-				spec.setErrorOutput(NullOutputStream.INSTANCE);
+				spec.setErrorOutput(NullOutputStream.NULL_OUTPUT_STREAM);
 			}
 		});
 	}


### PR DESCRIPTION
Fixes an issue I was encountering where `NullOutputStream.INSTANCE` did not exist - unsure why it did not, but this change doesn't change anything since `INSTANCE` and `NULL_OUTPUT_STREAM` are equivalent. Other parts of the code base already use NULL_OUTPUT_STREAM