### PR TITLE
fix: overwrite at in target jar.

### DIFF
--- a/src/main/java/dev/architectury/loom/extensions/ModBuildExtensions.java
+++ b/src/main/java/dev/architectury/loom/extensions/ModBuildExtensions.java
@@ -60,7 +60,7 @@ public final class ModBuildExtensions {
 			Path atPath = fs.getPath(Constants.Forge.ACCESS_TRANSFORMER_PATH);
 
 			if (Files.exists(atPath)) {
-				throw new FileAlreadyExistsException("Jar " + outputFile + " already contains an access transformer - cannot convert AWs!");
+				Files.delete(atPath);
 			}
 
 			for (String aw : atAccessWideners) {

--- a/src/main/java/dev/architectury/loom/extensions/ModBuildExtensions.java
+++ b/src/main/java/dev/architectury/loom/extensions/ModBuildExtensions.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;


### PR DESCRIPTION
In all projects with arch loom 1.9, the `remapJar` will fail due to this exception if you didn't `clean` before the `build`.  
The at already exists comes from the common project (shadow bundle), we can just ignore and delete it.