### PR TITLE
Avoid Mapping-IO limitations on modifying a mapping tree with active visitor.

### DIFF
--- a/src/main/java/net/fabricmc/loom/util/srg/ForgeMappingsMerger.java
+++ b/src/main/java/net/fabricmc/loom/util/srg/ForgeMappingsMerger.java
@@ -175,6 +175,7 @@ public final class ForgeMappingsMerger {
 			}
 		}
 
+		flatOutput.visitEnd();
 		resolveConflicts();
 
 		return output;
@@ -317,8 +318,14 @@ public final class ForgeMappingsMerger {
 			// Remove non-preferred methods
 			for (MethodData method : methods) {
 				if (method != preferred) {
-					MappingTree.ClassMapping clazz = output.getClass(method.obfOwner());
-					clazz.getMethods().removeIf(m -> m.getSrcName().equals(method.obfName()) && m.getSrcDesc().equals(method.obfDesc()));
+					MappingTree.ClassMapping classMapping = output.getClass(method.obfOwner());
+
+					// TODO: Change if/when MIO supports removals again
+					for (MappingTree.MethodMapping methodMapping : List.copyOf(classMapping.getMethods())) {
+						if (methodMapping.getSrcName().equals(method.obfName()) && methodMapping.getSrcDesc().equals(method.obfDesc())) {
+							classMapping.removeMethod(methodMapping.getSrcName(), methodMapping.getSrcDesc());
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I tried switching to the Mapping-IO API (like this commit: https://github.com/architectury/architectury-loom/commit/df1cfb2dce7e234d9190409f6391c9c5c339d5a5 ) but that just results in a Mapping-IO exception stating you can't modify a mapping with a visitor.  So I tried also closing the visitor just before the call to `resolveConflicts()` and that seems to work.

I'm not entirely certain this is the right way to resolve the issue, but it does seem to work and builds all three mod loader versions of Biolith in 1.21.5.

- Use Mapping-IO API when modifying its tree
- Close mapping visitor before modifying mapping tree
- Seems to avoid #276
