### PR TITLE
Update the gradle wrapper validation script to fix GitHub Actions.

### DIFF
--- a/.github/workflows/publish-exp.yml
+++ b/.github/workflows/publish-exp.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4
 
       # Generate the build number based on tags to allow per branch build numbers, not something github provides by default.
       - name: Generate build number

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4
       - name: Upload to Maven
         run: ./gradlew publish --stacktrace
         env:

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -15,7 +15,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4
       - run: ./gradlew build check -x test --stacktrace --warning-mode fail
       - uses: Juuxel/publish-checkstyle-report@v1
         if: ${{ failure() }}
@@ -32,7 +32,7 @@ jobs:
         with:
           java-version: 21
           distribution: 'temurin'
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4
       - run: ./gradlew build check -x test --stacktrace --warning-mode fail
 
   # This job is used to feed the test matrix of next job to allow the tests to run in parallel

--- a/src/main/java/net/fabricmc/loom/util/srg/ForgeMappingsMerger.java
+++ b/src/main/java/net/fabricmc/loom/util/srg/ForgeMappingsMerger.java
@@ -175,6 +175,7 @@ public final class ForgeMappingsMerger {
 			}
 		}
 
+		flatOutput.visitEnd();
 		resolveConflicts();
 
 		return output;
@@ -317,8 +318,14 @@ public final class ForgeMappingsMerger {
 			// Remove non-preferred methods
 			for (MethodData method : methods) {
 				if (method != preferred) {
-					MappingTree.ClassMapping clazz = output.getClass(method.obfOwner());
-					clazz.getMethods().removeIf(m -> m.getSrcName().equals(method.obfName()) && m.getSrcDesc().equals(method.obfDesc()));
+					MappingTree.ClassMapping classMapping = output.getClass(method.obfOwner());
+
+					// TODO: Change if/when MIO supports removals again
+					for (MappingTree.MethodMapping methodMapping : List.copyOf(classMapping.getMethods())) {
+						if (methodMapping.getSrcName().equals(method.obfName()) && methodMapping.getSrcDesc().equals(method.obfDesc())) {
+							classMapping.removeMethod(methodMapping.getSrcName(), methodMapping.getSrcDesc());
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The `gradle/wrapper-validation-action@v2` script (all versions, not just v2) has been superseded by `gradle/actions/wrapper-validation@v4` (v4 is the current version) and since then, it has ceased to work due to changes in resources on which it depends.  The latter is a drop-in replacement, which is what this PR does.

Evidence for my assertion, since this is a security-relevant script (purple colored note at top of README):
https://github.com/gradle/wrapper-validation-action
