### PR TITLE
Update the gradle wrapper validation script to fix GitHub Actions.

### DIFF
--- a/.github/workflows/publish-exp.yml
+++ b/.github/workflows/publish-exp.yml
@@ -14,7 +14,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4
 
       # Generate the build number based on tags to allow per branch build numbers, not something github provides by default.
       - name: Generate build number

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4
       - name: Upload to Maven
         run: ./gradlew publish --stacktrace
         env:

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -15,7 +15,7 @@ jobs:
           java-version: 21
           distribution: 'temurin'
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4
       - run: ./gradlew build check -x test --stacktrace --warning-mode fail
       - uses: Juuxel/publish-checkstyle-report@v1
         if: ${{ failure() }}
@@ -32,7 +32,7 @@ jobs:
         with:
           java-version: 21
           distribution: 'temurin'
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4
       - run: ./gradlew build check -x test --stacktrace --warning-mode fail
 
   # This job is used to feed the test matrix of next job to allow the tests to run in parallel


### PR DESCRIPTION
The `gradle/wrapper-validation-action@v2` script (all versions, not just v2) has been superseded by `gradle/actions/wrapper-validation@v4` (v4 is the current version) and since then, it has ceased to work due to changes in resources on which it depends.  The latter is a drop-in replacement, which is what this PR does.

Evidence for my assertion, since this is a security-relevant script (see purple colored note at top of README):
https://github.com/gradle/wrapper-validation-action
