### PR TITLE
Fixed gradle serialization issue inside ForgeRunTemplate for 1.10

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeRunTemplate.java
+++ b/src/main/java/net/fabricmc/loom/configuration/providers/forge/ForgeRunTemplate.java
@@ -25,6 +25,7 @@
 package net.fabricmc.loom.configuration.providers.forge;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -125,8 +126,9 @@ public record ForgeRunTemplate(
 		final Collector<Map.Entry<String, ConfigValue>, ?, Map<String, String>> resolveMap =
 				Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().resolve(configValueResolver));
 
-		final List<String> args = this.args.stream().map(resolve).toList();
-		final List<String> jvmArgs = this.jvmArgs.stream().map(resolve).toList();
+		// Do not use Stream.toList() as that is not serializable by gradle
+		final List<String> args = this.args.stream().map(resolve).collect(Collectors.toCollection(ArrayList::new));
+		final List<String> jvmArgs = this.jvmArgs.stream().map(resolve).collect(Collectors.toCollection(ArrayList::new));
 		final Map<String, String> env = this.env.entrySet().stream().collect(resolveMap);
 		final Map<String, String> props = this.props.entrySet().stream().collect(resolveMap);
 


### PR DESCRIPTION
This allows our project to enable ``org.gradle.configuration-cache`` for our build.
Since gradle can't serializ the static list versions only ArrayList etc.

That issue probably exist in a lot of versions, but I only care for 1.10, therefore the change is for that version only from my side.

<details>
<summary>The error message in question that this change fixes </summary>

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not load the value of field `args` of field `__runTemplates__` of task `:1.8.9:generateDLIConfig` of type `net.fabricmc.loom.task.launch.GenerateDLIConfigTask`.
> null array

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

* Exception is:
org.gradle.api.GradleException: Could not load the value of field `args` of field `__runTemplates__` of task `:1.8.9:generateDLIConfig` of type `net.fabricmc.loom.task.launch.GenerateDLIConfigTask`.
	at org.gradle.internal.serialize.graph.BeanPropertyExtensionsKt.readPropertyValue(BeanPropertyExtensions.kt:68)
	at org.gradle.internal.serialize.codecs.core.JavaRecordCodec.readFields(JavaRecordCodec.kt:63)
	at org.gradle.internal.serialize.codecs.core.JavaRecordCodec.decode(JavaRecordCodec.kt:46)
	at org.gradle.internal.serialize.graph.codecs.BindingsBackedCodec.decode(BindingsBackedCodec.kt:92)
	at org.gradle.internal.serialize.graph.DefaultReadContext.read(Contexts.kt:283)
	at org.gradle.internal.serialize.codecs.guava.ImmutableSetCodec.decode(ImmutableSetCodec.kt:39)
	at org.gradle.internal.serialize.graph.codecs.BindingsBackedCodec.decode(BindingsBackedCodec.kt:92)
	at org.gradle.internal.serialize.graph.DefaultReadContext.read(Contexts.kt:283)
	at org.gradle.internal.serialize.codecs.core.FixedValueReplacingProviderCodec.decodeValue(ProviderCodecs.kt:139)
	at org.gradle.internal.serialize.codecs.core.SetPropertyCodec.decode(ProviderCodecs.kt:434)
	at org.gradle.internal.serialize.graph.codecs.BindingsBackedCodec.decode(BindingsBackedCodec.kt:92)
	at org.gradle.internal.serialize.graph.DefaultReadContext.read(Contexts.kt:283)
	at org.gradle.internal.serialize.graph.BeanPropertyExtensionsKt.readPropertyValue(BeanPropertyExtensions.kt:61)
	at org.gradle.internal.serialize.beans.services.BeanPropertyReader.readFieldOf(BeanPropertyReader.kt:93)
	at org.gradle.internal.serialize.beans.services.BeanPropertyReader.readFieldsOf(BeanPropertyReader.kt:73)
	at org.gradle.internal.serialize.beans.services.BeanPropertyReader.readStateOf(BeanPropertyReader.kt:66)
	at org.gradle.internal.serialize.codecs.core.TaskNodeCodec$readTask$2.invokeSuspend(TaskNodeCodec.kt:134)
	at org.gradle.internal.serialize.codecs.core.TaskNodeCodec$readTask$2.invoke(TaskNodeCodec.kt)
	at org.gradle.internal.serialize.codecs.core.TaskNodeCodec$readTask$2.invoke(TaskNodeCodec.kt)
	at org.gradle.internal.serialize.codecs.core.TaskNodeCodecKt.withTaskOf(TaskNodeCodec.kt:236)
	at org.gradle.internal.serialize.codecs.core.TaskNodeCodecKt.access$withTaskOf(TaskNodeCodec.kt:1)
	at org.gradle.internal.serialize.codecs.core.TaskNodeCodec.readTask(TaskNodeCodec.kt:128)
	at org.gradle.internal.serialize.codecs.core.TaskNodeCodec.decode(TaskNodeCodec.kt:79)
	at org.gradle.internal.serialize.graph.codecs.BindingsBackedCodec.decode(BindingsBackedCodec.kt:92)
	at org.gradle.internal.serialize.graph.DefaultReadContext.read(Contexts.kt:283)
	at org.gradle.internal.serialize.graph.CodecKt.readNonNull(Codec.kt:159)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec.readNode(WorkNodeCodec.kt:405)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec.readGroupedNodes(WorkNodeCodec.kt:347)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec.access$readGroupedNodes(WorkNodeCodec.kt:81)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec$readNodes$1$1$1$1.invokeSuspend(WorkNodeCodec.kt:252)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec$readNodes$1$1$1$1.invoke(WorkNodeCodec.kt)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec$readNodes$1$1$1$1.invoke(WorkNodeCodec.kt)
	at org.gradle.internal.serialize.graph.CodecKt$readWith$1$1.invokeSuspend(Codec.kt:147)
	at org.gradle.internal.serialize.graph.CodecKt$readWith$1$1.invoke(Codec.kt)
	at org.gradle.internal.serialize.graph.CodecKt$readWith$1$1.invoke(Codec.kt)
	at org.gradle.internal.serialize.graph.RunningKt$runReadOperation$2.invokeSuspend(Running.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlin.coroutines.ContinuationKt.startCoroutine(Continuation.kt:115)
	at org.gradle.internal.serialize.graph.RunningKt.runToCompletion(Running.kt:54)
	at org.gradle.internal.serialize.graph.RunningKt.runReadOperation(Running.kt:32)
	at org.gradle.internal.serialize.graph.CodecKt.readWith(Codec.kt:146)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec$readNodes$1$1$1.invoke(WorkNodeCodec.kt:251)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec$readNodes$1$1$1.invoke(WorkNodeCodec.kt:250)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodecKt$asBuildOperation$1.run(WorkNodeCodec.kt:634)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:67)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:60)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:167)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:60)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor$QueueWorker.execute(DefaultBuildOperationExecutor.java:161)
	at org.gradle.internal.operations.DefaultBuildOperationQueue$WorkerRunnable.runOperation(DefaultBuildOperationQueue.java:272)
	at org.gradle.internal.operations.DefaultBuildOperationQueue$WorkerRunnable.doRunBatch(DefaultBuildOperationQueue.java:253)
	at org.gradle.internal.operations.DefaultBuildOperationQueue$WorkerRunnable.lambda$runBatch$1(DefaultBuildOperationQueue.java:226)
	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:125)
	at org.gradle.internal.operations.DefaultBuildOperationQueue$WorkerRunnable.runBatch(DefaultBuildOperationQueue.java:224)
	at org.gradle.internal.operations.DefaultBuildOperationQueue$WorkerRunnable.run(DefaultBuildOperationQueue.java:192)
	at org.gradle.internal.operations.DefaultBuildOperationQueue.waitForCompletion(DefaultBuildOperationQueue.java:105)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.executeInParallel(DefaultBuildOperationExecutor.java:106)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.runAllWithAccessToProjectState(DefaultBuildOperationExecutor.java:75)
	at org.gradle.internal.operations.DefaultBuildOperationExecutor.runAllWithAccessToProjectState(DefaultBuildOperationExecutor.java:70)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec$runBuildOperations$1.invoke(WorkNodeCodec.kt:582)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec$runBuildOperations$1.invoke(WorkNodeCodec.kt:581)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec.handleBuildOperationExceptions(WorkNodeCodec.kt:281)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec.runBuildOperations(WorkNodeCodec.kt:581)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec.readNodes(WorkNodeCodec.kt:248)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec.doRead(WorkNodeCodec.kt:131)
	at org.gradle.internal.serialize.codecs.core.WorkNodeCodec.readWork(WorkNodeCodec.kt:101)
	at org.gradle.internal.cc.impl.ConfigurationCacheState.readWorkGraph(ConfigurationCacheState.kt:521)
	at org.gradle.internal.cc.impl.ConfigurationCacheState.readBuildContent$configuration_cache(ConfigurationCacheState.kt:502)
	at org.gradle.internal.cc.impl.ConfigurationCacheState.readBuildState(ConfigurationCacheState.kt:353)
	at org.gradle.internal.cc.impl.ConfigurationCacheState.readBuildsInTree(ConfigurationCacheState.kt:315)
	at org.gradle.internal.cc.impl.ConfigurationCacheState.readRootBuild(ConfigurationCacheState.kt:288)
	at org.gradle.internal.cc.impl.ConfigurationCacheState.readRootBuildState(ConfigurationCacheState.kt:189)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readRootBuildStateFrom$1.invokeSuspend(DefaultConfigurationCacheIO.kt:227)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readRootBuildStateFrom$1.invoke(DefaultConfigurationCacheIO.kt)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readRootBuildStateFrom$1.invoke(DefaultConfigurationCacheIO.kt)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readConfigurationCacheStateWithSpecialDecoders$1.invokeSuspend(DefaultConfigurationCacheIO.kt:351)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readConfigurationCacheStateWithSpecialDecoders$1.invoke(DefaultConfigurationCacheIO.kt)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readConfigurationCacheStateWithSpecialDecoders$1.invoke(DefaultConfigurationCacheIO.kt)
	at org.gradle.internal.serialize.graph.CodecKt$readWith$1$1.invokeSuspend(Codec.kt:147)
	at org.gradle.internal.serialize.graph.CodecKt$readWith$1$1.invoke(Codec.kt)
	at org.gradle.internal.serialize.graph.CodecKt$readWith$1$1.invoke(Codec.kt)
	at org.gradle.internal.serialize.graph.RunningKt$runReadOperation$2.invokeSuspend(Running.kt:33)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlin.coroutines.ContinuationKt.startCoroutine(Continuation.kt:115)
	at org.gradle.internal.serialize.graph.RunningKt.runToCompletion(Running.kt:54)
	at org.gradle.internal.serialize.graph.RunningKt.runReadOperation(Running.kt:32)
	at org.gradle.internal.serialize.graph.CodecKt.readWith(Codec.kt:146)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.withReadContextFor(DefaultConfigurationCacheIO.kt:503)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.withReadContextFor(DefaultConfigurationCacheIO.kt:495)
	at org.gradle.internal.cc.impl.ConfigurationCacheBuildTreeIO$DefaultImpls.withReadContextFor(ConfigurationCacheBuildTreeIO.kt:83)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.withReadContextFor(DefaultConfigurationCacheIO.kt:94)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.readConfigurationCacheStateWithSpecialDecoders(DefaultConfigurationCacheIO.kt:349)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.access$readConfigurationCacheStateWithSpecialDecoders(DefaultConfigurationCacheIO.kt:94)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readConfigurationCacheState$1$1.invoke(DefaultConfigurationCacheIO.kt:257)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readConfigurationCacheState$1$1.invoke(DefaultConfigurationCacheIO.kt:256)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.withSharedObjectDecoderFor(DefaultConfigurationCacheIO.kt:333)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.access$withSharedObjectDecoderFor(DefaultConfigurationCacheIO.kt:94)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readConfigurationCacheState$1.invoke(DefaultConfigurationCacheIO.kt:256)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO$readConfigurationCacheState$1.invoke(DefaultConfigurationCacheIO.kt:255)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.withStringDecoderFor(DefaultConfigurationCacheIO.kt:321)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.readConfigurationCacheState(DefaultConfigurationCacheIO.kt:255)
	at org.gradle.internal.cc.impl.DefaultConfigurationCacheIO.readRootBuildStateFrom(DefaultConfigurationCacheIO.kt:225)
	at org.gradle.internal.cc.impl.DefaultConfigurationCache$loadWorkGraph$1$1$storeLoadResult$1.invoke(DefaultConfigurationCache.kt:657)
	at org.gradle.internal.cc.impl.DefaultConfigurationCache$loadWorkGraph$1$1$storeLoadResult$1.invoke(DefaultConfigurationCache.kt:656)
	at org.gradle.internal.cc.impl.ConfigurationCacheRepository$StoreImpl$useForStateLoad$1.invoke(ConfigurationCacheRepository.kt:231)
	at org.gradle.internal.cc.impl.ConfigurationCacheRepository$StoreImpl$useForStateLoad$1.invoke(ConfigurationCacheRepository.kt:231)
	at org.gradle.internal.cc.impl.ConfigurationCacheRepository$StoreImpl$useForStateLoad$2.invoke(ConfigurationCacheRepository.kt:239)
	at org.gradle.internal.cc.impl.ConfigurationCacheRepository$StoreImpl$useForStateLoad$2.invoke(ConfigurationCacheRepository.kt:235)
	at org.gradle.internal.cc.impl.ConfigurationCacheRepository$withExclusiveAccessToCache$1.get(ConfigurationCacheRepository.kt:320)
	at org.gradle.cache.internal.LockOnDemandCrossProcessCacheAccess.withFileLock(LockOnDemandCrossProcessCacheAccess.java:90)
	at org.gradle.cache.internal.DefaultCacheCoordinator.withFileLock(DefaultCacheCoordinator.java:213)
	at org.gradle.cache.internal.DefaultPersistentDirectoryStore.withFileLock(DefaultPersistentDirectoryStore.java:147)
	at org.gradle.cache.internal.DefaultCacheFactory$ReferenceTrackingCache.withFileLock(DefaultCacheFactory.java:203)
	at org.gradle.internal.cc.impl.ConfigurationCacheRepository.withExclusiveAccessToCache(ConfigurationCacheRepository.kt:318)
	at org.gradle.internal.cc.impl.ConfigurationCacheRepository.access$withExclusiveAccessToCache(ConfigurationCacheRepository.kt:54)
	at org.gradle.internal.cc.impl.ConfigurationCacheRepository$StoreImpl.useForStateLoad(ConfigurationCacheRepository.kt:235)
	at org.gradle.internal.cc.impl.ConfigurationCacheRepository$StoreImpl.useForStateLoad(ConfigurationCacheRepository.kt:231)
	at org.gradle.internal.cc.impl.DefaultConfigurationCache$loadWorkGraph$1$1.invoke(DefaultConfigurationCache.kt:656)
	at org.gradle.internal.cc.impl.DefaultConfigurationCache$loadWorkGraph$1$1.invoke(DefaultConfigurationCache.kt:655)
	at org.gradle.configurationcache.ConfigurationCacheBuildOperationsKt$withWorkGraphLoadOperation$1.call(ConfigurationCacheBuildOperations.kt:47)
	at org.gradle.configurationcache.ConfigurationCacheBuildOperationsKt$withWorkGraphLoadOperation$1.call(ConfigurationCacheBuildOperations.kt:40)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:210)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:205)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:67)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:60)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:167)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:60)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:54)
	at org.gradle.configurationcache.ConfigurationCacheBuildOperationsKt.withWorkGraphLoadOperation(ConfigurationCacheBuildOperations.kt:40)
	at org.gradle.internal.cc.impl.DefaultConfigurationCache.loadWorkGraph(DefaultConfigurationCache.kt:655)
	at org.gradle.internal.cc.impl.DefaultConfigurationCache.loadRequestedTasks(DefaultConfigurationCache.kt:253)
	at org.gradle.internal.cc.impl.ConfigurationCacheAwareBuildTreeWorkController$scheduleAndRunRequestedTasks$3.apply(ConfigurationCacheAwareBuildTreeWorkController.kt:69)
	at org.gradle.internal.cc.impl.ConfigurationCacheAwareBuildTreeWorkController$scheduleAndRunRequestedTasks$3.apply(ConfigurationCacheAwareBuildTreeWorkController.kt:68)
	at org.gradle.composite.internal.DefaultIncludedBuildTaskGraph.withNewWorkGraph(DefaultIncludedBuildTaskGraph.java:112)
	at org.gradle.internal.cc.impl.ConfigurationCacheAwareBuildTreeWorkController.scheduleAndRunRequestedTasks(ConfigurationCacheAwareBuildTreeWorkController.kt:68)
	at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.lambda$scheduleAndRunTasks$1(DefaultBuildTreeLifecycleController.java:77)
	at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.lambda$runBuild$4(DefaultBuildTreeLifecycleController.java:120)
	at org.gradle.internal.model.StateTransitionController.lambda$transition$6(StateTransitionController.java:169)
	at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:266)
	at org.gradle.internal.model.StateTransitionController.lambda$transition$7(StateTransitionController.java:169)
	at org.gradle.internal.work.DefaultSynchronizer.withLock(DefaultSynchronizer.java:46)
	at org.gradle.internal.model.StateTransitionController.transition(StateTransitionController.java:169)
	at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.runBuild(DefaultBuildTreeLifecycleController.java:117)
	at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.scheduleAndRunTasks(DefaultBuildTreeLifecycleController.java:77)
	at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.scheduleAndRunTasks(DefaultBuildTreeLifecycleController.java:72)
	at org.gradle.tooling.internal.provider.runner.BuildModelActionRunner.run(BuildModelActionRunner.java:53)
	at org.gradle.launcher.exec.ChainingBuildActionRunner.run(ChainingBuildActionRunner.java:35)
	at org.gradle.internal.buildtree.ProblemReportingBuildActionRunner.run(ProblemReportingBuildActionRunner.java:49)
	at org.gradle.launcher.exec.BuildOutcomeReportingBuildActionRunner.run(BuildOutcomeReportingBuildActionRunner.java:71)
	at org.gradle.tooling.internal.provider.FileSystemWatchingBuildActionRunner.run(FileSystemWatchingBuildActionRunner.java:135)
	at org.gradle.launcher.exec.BuildCompletionNotifyingBuildActionRunner.run(BuildCompletionNotifyingBuildActionRunner.java:41)
	at org.gradle.launcher.exec.RootBuildLifecycleBuildActionExecutor.lambda$execute$0(RootBuildLifecycleBuildActionExecutor.java:54)
	at org.gradle.composite.internal.DefaultRootBuildState.run(DefaultRootBuildState.java:130)
	at org.gradle.launcher.exec.RootBuildLifecycleBuildActionExecutor.execute(RootBuildLifecycleBuildActionExecutor.java:54)
	at org.gradle.internal.buildtree.InitDeprecationLoggingActionExecutor.execute(InitDeprecationLoggingActionExecutor.java:62)
	at org.gradle.internal.buildtree.InitProblems.execute(InitProblems.java:36)
	at org.gradle.internal.buildtree.DefaultBuildTreeContext.execute(DefaultBuildTreeContext.java:40)
	at org.gradle.launcher.exec.BuildTreeLifecycleBuildActionExecutor.lambda$execute$0(BuildTreeLifecycleBuildActionExecutor.java:71)
	at org.gradle.internal.buildtree.BuildTreeState.run(BuildTreeState.java:60)
	at org.gradle.launcher.exec.BuildTreeLifecycleBuildActionExecutor.execute(BuildTreeLifecycleBuildActionExecutor.java:71)
	at org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor$2.call(RunAsBuildOperationBuildActionExecutor.java:67)
	at org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor$2.call(RunAsBuildOperationBuildActionExecutor.java:63)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:210)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:205)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:67)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:60)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:167)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:60)
	at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:54)
	at org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor.execute(RunAsBuildOperationBuildActionExecutor.java:63)
	at org.gradle.launcher.exec.RunAsWorkerThreadBuildActionExecutor.lambda$execute$0(RunAsWorkerThreadBuildActionExecutor.java:36)
	at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:263)
	at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:127)
	at org.gradle.launcher.exec.RunAsWorkerThreadBuildActionExecutor.execute(RunAsWorkerThreadBuildActionExecutor.java:36)
	at org.gradle.tooling.internal.provider.continuous.ContinuousBuildActionExecutor.execute(ContinuousBuildActionExecutor.java:110)
	at org.gradle.tooling.internal.provider.SubscribableBuildActionExecutor.execute(SubscribableBuildActionExecutor.java:64)
	at org.gradle.internal.session.DefaultBuildSessionContext.execute(DefaultBuildSessionContext.java:46)
	at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor$ActionImpl.apply(BuildSessionLifecycleBuildActionExecutor.java:92)
	at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor$ActionImpl.apply(BuildSessionLifecycleBuildActionExecutor.java:80)
	at org.gradle.internal.session.BuildSessionState.run(BuildSessionState.java:73)
	at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor.execute(BuildSessionLifecycleBuildActionExecutor.java:62)
	at org.gradle.internal.buildprocess.execution.BuildSessionLifecycleBuildActionExecutor.execute(BuildSessionLifecycleBuildActionExecutor.java:41)
	at org.gradle.internal.buildprocess.execution.StartParamsValidatingActionExecutor.execute(StartParamsValidatingActionExecutor.java:64)
	at org.gradle.internal.buildprocess.execution.StartParamsValidatingActionExecutor.execute(StartParamsValidatingActionExecutor.java:32)
	at org.gradle.internal.buildprocess.execution.SessionFailureReportingActionExecutor.execute(SessionFailureReportingActionExecutor.java:51)
	at org.gradle.internal.buildprocess.execution.SessionFailureReportingActionExecutor.execute(SessionFailureReportingActionExecutor.java:39)
	at org.gradle.internal.buildprocess.execution.SetupLoggingActionExecutor.execute(SetupLoggingActionExecutor.java:47)
	at org.gradle.internal.buildprocess.execution.SetupLoggingActionExecutor.execute(SetupLoggingActionExecutor.java:31)
	at org.gradle.launcher.daemon.server.exec.ExecuteBuild.doBuild(ExecuteBuild.java:70)
	at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
	at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
	at org.gradle.launcher.daemon.server.exec.WatchForDisconnection.execute(WatchForDisconnection.java:39)
	at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
	at org.gradle.launcher.daemon.server.exec.ResetDeprecationLogger.execute(ResetDeprecationLogger.java:29)
	at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
	at org.gradle.launcher.daemon.server.exec.RequestStopIfSingleUsedDaemon.execute(RequestStopIfSingleUsedDaemon.java:35)
	at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
	at org.gradle.launcher.daemon.server.exec.ForwardClientInput.lambda$execute$0(ForwardClientInput.java:40)
	at org.gradle.internal.daemon.clientinput.ClientInputForwarder.forwardInput(ClientInputForwarder.java:80)
	at org.gradle.launcher.daemon.server.exec.ForwardClientInput.execute(ForwardClientInput.java:37)
	at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
	at org.gradle.launcher.daemon.server.exec.LogAndCheckHealth.execute(LogAndCheckHealth.java:64)
	at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
	at org.gradle.launcher.daemon.server.exec.LogToClient.doBuild(LogToClient.java:63)
	at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
	at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
	at org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment.doBuild(EstablishBuildEnvironment.java:84)
	at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
	at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
	at org.gradle.launcher.daemon.server.exec.StartBuildOrRespondWithBusy$1.run(StartBuildOrRespondWithBusy.java:52)
	at org.gradle.launcher.daemon.server.DaemonStateCoordinator.lambda$runCommand$0(DaemonStateCoordinator.java:321)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
Caused by: java.io.InvalidObjectException: null array
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at org.gradle.internal.serialize.codecs.core.jos.JavaObjectSerializationCodec.readResolve(JavaObjectSerializationCodec.kt:197)
	at org.gradle.internal.serialize.codecs.core.jos.JavaObjectSerializationCodec.decode(JavaObjectSerializationCodec.kt:111)
	at org.gradle.internal.serialize.graph.codecs.BindingsBackedCodec.decode(BindingsBackedCodec.kt:92)
	at org.gradle.internal.serialize.graph.DefaultReadContext.read(Contexts.kt:283)
	at org.gradle.internal.serialize.graph.BeanPropertyExtensionsKt.readPropertyValue(BeanPropertyExtensions.kt:61)
	... 212 more
```

</details>

