### PR TITLE
Fix FileAlreadyExistsException on Forge when refreshing Gradle dependencies

### DIFF
--- a/src/main/java/dev/architectury/loom/forge/dependency/ForgeUniversalProvider.java
+++ b/src/main/java/dev/architectury/loom/forge/dependency/ForgeUniversalProvider.java
@@ -26,6 +26,7 @@ package dev.architectury.loom.forge.dependency;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 import org.gradle.api.Project;
 
@@ -45,7 +46,7 @@ public class ForgeUniversalProvider extends DependencyProvider {
 
 		if (!forge.exists() || refreshDeps()) {
 			File dep = dependency.resolveFile().orElseThrow(() -> new RuntimeException("Could not resolve Forge"));
-			Files.copy(dep.toPath(), forge.toPath());
+			Files.copy(dep.toPath(), forge.toPath(), StandardCopyOption.REPLACE_EXISTING);
 		}
 	}
 


### PR DESCRIPTION
Tested with Forge 47.4.0 (MC 1.20.1), fixes an issue where every time you refresh Gradle you'd be greeted with a `FileAlreadyExistsException` on Loom 1.13, haven't tested any older versions so unsure if they're affected there.