### PR TITLE
Fix NeoForge 21.10.x support for multi-platform projects

### DIFF
--- a/src/main/java/dev/architectury/loom/forge/config/ForgeRunTemplate.java
+++ b/src/main/java/dev/architectury/loom/forge/config/ForgeRunTemplate.java
@@ -107,9 +107,17 @@ public record ForgeRunTemplate(
 	}
 
 	public void applyTo(RunConfigSettings settings, ConfigValue.Resolver configValueResolver) {
-		if (settings.getDefaultMainClass().equals(Constants.Forge.UNDETERMINED_MAIN_CLASS)) {
-			settings.defaultMainClass(main);
-		}
+// DEBUG: Log the main class being applied
+settings.getProject().getLogger().lifecycle("[ForgeRunTemplate.applyTo] Template name: " + name + ", main class: " + main);
+settings.getProject().getLogger().lifecycle("[ForgeRunTemplate.applyTo] Current defaultMainClass: " + settings.getDefaultMainClass());
+
+// Always set the main class from the NeoForge/Forge template.
+// Previously this only set it if defaultMainClass == UNDETERMINED_MAIN_CLASS,
+// but client/server configs already have KNOT_CLIENT/KNOT_SERVER from Fabric defaults,
+// so the NeoForge main class (e.g. net.neoforged.devlaunch.Main) was never applied.
+settings.defaultMainClass(main);
+
+settings.getProject().getLogger().lifecycle("[ForgeRunTemplate.applyTo] After setting: " + settings.getDefaultMainClass());
 
 		settings.vmArgs(CollectionUtil.map(jvmArgs, value -> value.resolve(configValueResolver)));
 

--- a/src/main/java/dev/architectury/loom/forge/config/UserdevConfig.java
+++ b/src/main/java/dev/architectury/loom/forge/config/UserdevConfig.java
@@ -13,72 +13,81 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.fabricmc.loom.util.IOFunction;
 
 public record UserdevConfig(
-		String mcp,
-		String universal,
-		String sources,
-		String patches,
-		Optional<String> patchesOriginalPrefix,
-		Optional<String> patchesModifiedPrefix,
-		String binpatches,
-		BinaryPatcherConfig binpatcher,
-		List<String> libraries,
-		Map<String, ForgeRunTemplate> runs,
-		List<String> sass,
-		AccessTransformerLocation ats
+String mcp,
+String universal,
+String sources,
+String patches,
+Optional<String> patchesOriginalPrefix,
+Optional<String> patchesModifiedPrefix,
+String binpatches,
+BinaryPatcherConfig binpatcher,
+List<String> libraries,
+Map<String, ForgeRunTemplate> runs,
+List<String> sass,
+AccessTransformerLocation ats,
+Features features
 ) {
-	public static final Codec<UserdevConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-			Codec.STRING.fieldOf("mcp").forGetter(UserdevConfig::mcp),
-			Codec.STRING.fieldOf("universal").forGetter(UserdevConfig::universal),
-			Codec.STRING.fieldOf("sources").forGetter(UserdevConfig::sources),
-			Codec.STRING.fieldOf("patches").forGetter(UserdevConfig::patches),
-			Codec.STRING.optionalFieldOf("patchesOriginalPrefix").forGetter(UserdevConfig::patchesOriginalPrefix),
-			Codec.STRING.optionalFieldOf("patchesModifiedPrefix").forGetter(UserdevConfig::patchesModifiedPrefix),
-			Codec.STRING.fieldOf("binpatches").forGetter(UserdevConfig::binpatches),
-			BinaryPatcherConfig.CODEC.fieldOf("binpatcher").forGetter(UserdevConfig::binpatcher),
-			Codec.STRING.listOf().fieldOf("libraries").forGetter(UserdevConfig::libraries),
-			ForgeRunTemplate.MAP_CODEC.fieldOf("runs").forGetter(UserdevConfig::runs),
-			Codec.STRING.listOf().optionalFieldOf("sass", List.of()).forGetter(UserdevConfig::sass),
-			AccessTransformerLocation.CODEC.fieldOf("ats").forGetter(UserdevConfig::ats)
-	).apply(instance, UserdevConfig::new));
+public static final Codec<UserdevConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+Codec.STRING.fieldOf("mcp").forGetter(UserdevConfig::mcp),
+Codec.STRING.fieldOf("universal").forGetter(UserdevConfig::universal),
+Codec.STRING.fieldOf("sources").forGetter(UserdevConfig::sources),
+Codec.STRING.fieldOf("patches").forGetter(UserdevConfig::patches),
+Codec.STRING.optionalFieldOf("patchesOriginalPrefix").forGetter(UserdevConfig::patchesOriginalPrefix),
+Codec.STRING.optionalFieldOf("patchesModifiedPrefix").forGetter(UserdevConfig::patchesModifiedPrefix),
+Codec.STRING.fieldOf("binpatches").forGetter(UserdevConfig::binpatches),
+BinaryPatcherConfig.CODEC.fieldOf("binpatcher").forGetter(UserdevConfig::binpatcher),
+Codec.STRING.listOf().fieldOf("libraries").forGetter(UserdevConfig::libraries),
+ForgeRunTemplate.MAP_CODEC.fieldOf("runs").forGetter(UserdevConfig::runs),
+Codec.STRING.listOf().optionalFieldOf("sass", List.of()).forGetter(UserdevConfig::sass),
+AccessTransformerLocation.CODEC.fieldOf("ats").forGetter(UserdevConfig::ats),
+Features.CODEC.optionalFieldOf("features", Features.DEFAULT).forGetter(UserdevConfig::features)
+).apply(instance, UserdevConfig::new));
 
-	public record BinaryPatcherConfig(String dependency, List<String> args) {
-		public static final Codec<BinaryPatcherConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-				Codec.STRING.fieldOf("version").forGetter(BinaryPatcherConfig::dependency),
-				Codec.STRING.listOf().fieldOf("args").forGetter(BinaryPatcherConfig::args)
-		).apply(instance, BinaryPatcherConfig::new));
-	}
+public record BinaryPatcherConfig(String dependency, List<String> args) {
+public static final Codec<BinaryPatcherConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+Codec.STRING.fieldOf("version").forGetter(BinaryPatcherConfig::dependency),
+Codec.STRING.listOf().fieldOf("args").forGetter(BinaryPatcherConfig::args)
+).apply(instance, BinaryPatcherConfig::new));
+}
 
-	public sealed interface AccessTransformerLocation {
-		Codec<AccessTransformerLocation> CODEC = Codec.either(Codec.STRING, Codec.STRING.listOf()).xmap(
-				either -> either.map(Directory::new, FileList::new),
-				location -> location.visit(Either::left, Either::right)
-		);
+public record Features(boolean combinedBinaryPatches) {
+public static final Features DEFAULT = new Features(false);
+public static final Codec<Features> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+Codec.BOOL.optionalFieldOf("combinedBinaryPatches", false).forGetter(Features::combinedBinaryPatches)
+).apply(instance, Features::new));
+}
 
-		<T> T visit(Function<String, T> ifDirectory, Function<List<String>, T> ifFileList);
-		<T> T visitIo(IOFunction<String, T> ifDirectory, IOFunction<List<String>, T> ifFileList) throws IOException;
+public sealed interface AccessTransformerLocation {
+Codec<AccessTransformerLocation> CODEC = Codec.either(Codec.STRING, Codec.STRING.listOf()).xmap(
+either -> either.map(Directory::new, FileList::new),
+location -> location.visit(Either::left, Either::right)
+);
 
-		record Directory(String path) implements AccessTransformerLocation {
-			@Override
-			public <T> T visit(Function<String, T> ifDirectory, Function<List<String>, T> ifFileList) {
-				return ifDirectory.apply(path);
-			}
+<T> T visit(Function<String, T> ifDirectory, Function<List<String>, T> ifFileList);
+<T> T visitIo(IOFunction<String, T> ifDirectory, IOFunction<List<String>, T> ifFileList) throws IOException;
 
-			@Override
-			public <T> T visitIo(IOFunction<String, T> ifDirectory, IOFunction<List<String>, T> ifFileList) throws IOException {
-				return ifDirectory.apply(path);
-			}
-		}
+record Directory(String path) implements AccessTransformerLocation {
+@Override
+public <T> T visit(Function<String, T> ifDirectory, Function<List<String>, T> ifFileList) {
+return ifDirectory.apply(path);
+}
 
-		record FileList(List<String> paths) implements AccessTransformerLocation {
-			@Override
-			public <T> T visit(Function<String, T> ifDirectory, Function<List<String>, T> ifFileList) {
-				return ifFileList.apply(paths);
-			}
+@Override
+public <T> T visitIo(IOFunction<String, T> ifDirectory, IOFunction<List<String>, T> ifFileList) throws IOException {
+return ifDirectory.apply(path);
+}
+}
 
-			@Override
-			public <T> T visitIo(IOFunction<String, T> ifDirectory, IOFunction<List<String>, T> ifFileList) throws IOException {
-				return ifFileList.apply(paths);
-			}
-		}
-	}
+record FileList(List<String> paths) implements AccessTransformerLocation {
+@Override
+public <T> T visit(Function<String, T> ifDirectory, Function<List<String>, T> ifFileList) {
+return ifFileList.apply(paths);
+}
+
+@Override
+public <T> T visitIo(IOFunction<String, T> ifDirectory, IOFunction<List<String>, T> ifFileList) throws IOException {
+return ifFileList.apply(paths);
+}
+}
+}
 }

--- a/src/main/java/dev/architectury/loom/forge/dependency/ForgeProvider.java
+++ b/src/main/java/dev/architectury/loom/forge/dependency/ForgeProvider.java
@@ -57,13 +57,14 @@ public class ForgeProvider extends DependencyProvider {
 	}
 
 	public boolean usesMojangAtRuntime() {
-		return platform == ModPlatform.NEOFORGE || version.getMajorVersion() >= Constants.Forge.MIN_USE_MOJANG_NS_VERSION;
+		return getExtension().isNeoForge() || version.getMajorVersion() >= Constants.Forge.MIN_USE_MOJANG_NS_VERSION;
 	}
 
 	public File getGlobalCache() {
 		if (globalCache == null) {
 			Objects.requireNonNull(version.getCombined(), "Forge provider version is null when trying to get project directory");
-			globalCache = getMinecraftProvider().dir(platform.id() + "/" + version.getCombined());
+			String platformId = getExtension().isNeoForge() ? "neoforge" : "forge";
+			globalCache = getMinecraftProvider().dir(platformId + "/" + version.getCombined());
 			globalCache.mkdirs();
 		}
 
@@ -72,7 +73,7 @@ public class ForgeProvider extends DependencyProvider {
 
 	@Override
 	public String getTargetConfig() {
-		return platform == ModPlatform.NEOFORGE ? Constants.Configurations.NEOFORGE : Constants.Configurations.FORGE;
+		return getExtension().isNeoForge() ? Constants.Configurations.NEOFORGE : Constants.Configurations.FORGE;
 	}
 
 	/**
@@ -82,11 +83,11 @@ public class ForgeProvider extends DependencyProvider {
 	 */
 	public static Path getForgeCache(Project project) {
 		final LoomGradleExtension extension = LoomGradleExtension.get(project);
-		final ModPlatform platform = extension.getPlatform().get();
 		final String version = extension.getForgeProvider().getVersion().getCombined();
 		Objects.requireNonNull(version, "Forge provider version is null when trying to get project directory");
+		String platformId = extension.isNeoForge() ? "neoforge" : "forge";
 		return LoomGradleExtension.get(project).getMinecraftProvider()
-				.dir(platform.id() + "/" + version).toPath();
+				.dir(platformId + "/" + version).toPath();
 	}
 
 	public static final class ForgeVersion {

--- a/src/main/java/dev/architectury/loom/forge/minecraft/MinecraftPatchedProvider.java
+++ b/src/main/java/dev/architectury/loom/forge/minecraft/MinecraftPatchedProvider.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
@@ -60,9 +61,12 @@ import dev.architectury.loom.forge.dependency.ForgeUserdevProvider;
 import dev.architectury.loom.forge.dependency.PatchProvider;
 import dev.architectury.loom.forge.tool.ForgeToolValueSource;
 import dev.architectury.loom.mappings.MappingOption;
+import dev.architectury.loom.mcpconfig.McpConfigFunction;
 import dev.architectury.loom.mcpconfig.McpConfigProvider;
 import dev.architectury.loom.mcpconfig.McpExecutor;
 import dev.architectury.loom.mcpconfig.McpExecutorBuilder;
+import dev.architectury.loom.mcpconfig.steplogic.FunctionLogic;
+import dev.architectury.loom.mcpconfig.steplogic.StepLogic;
 import dev.architectury.loom.neoforge.SidedJarIndexGenerator;
 import dev.architectury.loom.util.DependencyDownloader;
 import dev.architectury.loom.util.Stopwatch;
@@ -194,6 +198,26 @@ public class MinecraftPatchedProvider {
 
 			try (var tempFiles = new TempFiles(); var serviceFactory = new ScopedServiceFactory()) {
 				McpExecutorBuilder builder = createMcpExecutor(tempFiles.directory("loom-mcp"));
+
+				// For NeoForge 21.10.57+ with combinedBinaryPatches, modify rename args
+				// to match ProcessMinecraftJar (add --strip-sigs, remove --unfinal-params)
+				ForgeUserdevProvider userdevProvider = getExtension().getForgeUserdevProvider();
+				if (userdevProvider.getConfig().features().combinedBinaryPatches()) {
+					builder.setStepLogicProvider((context, name, type) -> {
+						if ("rename".equals(type)) {
+							McpConfigFunction originalFunction = builder.getFunctions().get(type);
+							if (originalFunction != null) {
+								McpConfigFunction modifiedFunction = originalFunction.withModifiedArgs(
+										List.of("--strip-sigs"),
+										Set.of("--unfinal-params")
+								);
+								return FunctionLogic.createOptions(context, modifiedFunction);
+							}
+						}
+						return null;
+					});
+				}
+
 				builder.enqueue("rename");
 				McpExecutor executor = serviceFactory.get(builder.build());
 				Path output = executor.execute();

--- a/src/main/java/dev/architectury/loom/mappings/MappingOption.java
+++ b/src/main/java/dev/architectury/loom/mappings/MappingOption.java
@@ -3,15 +3,17 @@ package dev.architectury.loom.mappings;
 import net.fabricmc.loom.api.LoomGradleExtensionAPI;
 
 public enum MappingOption {
-	DEFAULT,
-	WITH_SRG,
-	WITH_MOJANG;
+DEFAULT,
+WITH_SRG,
+WITH_MOJANG;
 
-	public static MappingOption forPlatform(LoomGradleExtensionAPI extension) {
-		return switch (extension.getPlatform().get()) {
-		case FORGE -> WITH_SRG;
-		case NEOFORGE -> WITH_MOJANG;
-		default -> DEFAULT;
-		};
-	}
+public static MappingOption forPlatform(LoomGradleExtensionAPI extension) {
+// Use detected status instead of platform enum for Architectury support
+if (extension.isNeoForge()) {
+return WITH_MOJANG;
+} else if (extension.isForge()) {
+return WITH_SRG;
+}
+return DEFAULT;
+}
 }

--- a/src/main/java/dev/architectury/loom/mcpconfig/McpConfigFunction.java
+++ b/src/main/java/dev/architectury/loom/mcpconfig/McpConfigFunction.java
@@ -27,7 +27,9 @@ package dev.architectury.loom.mcpconfig;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -46,51 +48,76 @@ import org.jetbrains.annotations.Nullable;
  * @param repo    the Maven repository to download the dependency from, or {@code null} if not specified
  */
 public record McpConfigFunction(String version, List<ConfigValue> args, List<ConfigValue> jvmArgs, @Nullable String repo) implements Serializable {
-	private static final String VERSION_KEY = "version";
-	private static final String ARGS_KEY = "args";
-	private static final String JVM_ARGS_KEY = "jvmargs";
-	private static final String REPO_KEY = "repo";
+private static final String VERSION_KEY = "version";
+private static final String ARGS_KEY = "args";
+private static final String JVM_ARGS_KEY = "jvmargs";
+private static final String REPO_KEY = "repo";
 
-	public Path download(StepLogic.SetupContext executionContext) throws IOException {
-		if (repo != null) {
-			return executionContext.downloadFile(getDownloadUrl());
-		} else {
-			return executionContext.downloadDependency(version);
-		}
-	}
+public Path download(StepLogic.SetupContext executionContext) throws IOException {
+if (repo != null) {
+return executionContext.downloadFile(getDownloadUrl());
+} else {
+return executionContext.downloadDependency(version);
+}
+}
 
-	private String getDownloadUrl() {
-		String[] parts = version.split(":");
-		StringBuilder builder = new StringBuilder();
-		builder.append(repo);
-		// Group:
-		builder.append(parts[0].replace('.', '/')).append('/');
-		// Name:
-		builder.append(parts[1]).append('/');
-		// Version:
-		builder.append(parts[2]).append('/');
-		// Artifact:
-		builder.append(parts[1]).append('-').append(parts[2]);
+private String getDownloadUrl() {
+String[] parts = version.split(":");
+StringBuilder builder = new StringBuilder();
+builder.append(repo);
+// Group:
+builder.append(parts[0].replace('.', '/')).append('/');
+// Name:
+builder.append(parts[1]).append('/');
+// Version:
+builder.append(parts[2]).append('/');
+// Artifact:
+builder.append(parts[1]).append('-').append(parts[2]);
 
-		// Classifier:
-		if (parts.length >= 4) {
-			builder.append('-').append(parts[3]);
-		}
+// Classifier:
+if (parts.length >= 4) {
+builder.append('-').append(parts[3]);
+}
 
-		builder.append(".jar");
-		return builder.toString();
-	}
+builder.append(".jar");
+return builder.toString();
+}
 
-	public static McpConfigFunction fromJson(JsonObject json) {
-		String version = json.get(VERSION_KEY).getAsString();
-		List<ConfigValue> args = json.has(ARGS_KEY) ? configValuesFromJson(json.getAsJsonArray(ARGS_KEY)) : List.of();
-		List<ConfigValue> jvmArgs = json.has(JVM_ARGS_KEY) ? configValuesFromJson(json.getAsJsonArray(JVM_ARGS_KEY)) : List.of();
-		JsonElement repoJson = json.get(REPO_KEY);
-		@Nullable String repo = repoJson.isJsonPrimitive() ? repoJson.getAsString() : null;
-		return new McpConfigFunction(version, args, jvmArgs, repo);
-	}
+/**
+ * Creates a new function with modified arguments.
+ *
+ * @param argsToAdd    arguments to add to the end
+ * @param argsToRemove arguments to remove (matched by the literal value)
+ * @return a new McpConfigFunction with modified args
+ */
+public McpConfigFunction withModifiedArgs(List<String> argsToAdd, Set<String> argsToRemove) {
+List<ConfigValue> newArgs = new ArrayList<>();
 
-	private static List<ConfigValue> configValuesFromJson(JsonArray json) {
-		return CollectionUtil.map(json, child -> ConfigValue.of(child.getAsString()));
-	}
+// Copy existing args, filtering out ones to remove
+for (ConfigValue arg : args) {
+if (!(arg instanceof ConfigValue.Constant c && argsToRemove.contains(c.value()))) {
+newArgs.add(arg);
+}
+}
+
+// Add new args
+for (String arg : argsToAdd) {
+newArgs.add(ConfigValue.of(arg));
+}
+
+return new McpConfigFunction(version, List.copyOf(newArgs), jvmArgs, repo);
+}
+
+public static McpConfigFunction fromJson(JsonObject json) {
+String version = json.get(VERSION_KEY).getAsString();
+List<ConfigValue> args = json.has(ARGS_KEY) ? configValuesFromJson(json.getAsJsonArray(ARGS_KEY)) : List.of();
+List<ConfigValue> jvmArgs = json.has(JVM_ARGS_KEY) ? configValuesFromJson(json.getAsJsonArray(JVM_ARGS_KEY)) : List.of();
+JsonElement repoJson = json.get(REPO_KEY);
+@Nullable String repo = repoJson.isJsonPrimitive() ? repoJson.getAsString() : null;
+return new McpConfigFunction(version, args, jvmArgs, repo);
+}
+
+private static List<ConfigValue> configValuesFromJson(JsonArray json) {
+return CollectionUtil.map(json, child -> ConfigValue.of(child.getAsString()));
+}
 }

--- a/src/main/java/dev/architectury/loom/mcpconfig/McpExecutorBuilder.java
+++ b/src/main/java/dev/architectury/loom/mcpconfig/McpExecutorBuilder.java
@@ -212,6 +212,13 @@ public final class McpExecutorBuilder {
 		this.stepLogicProvider = stepLogicProvider;
 	}
 
+	/**
+	 * Returns the map of MCP config functions.
+	 */
+	public Map<String, McpConfigFunction> getFunctions() {
+		return functions;
+	}
+
 	private boolean isNoOp(String stepType) {
 		return "downloadManifest".equals(stepType) || "downloadJson".equals(stepType);
 	}

--- a/src/main/java/net/fabricmc/loom/build/nesting/JarNester.java
+++ b/src/main/java/net/fabricmc/loom/build/nesting/JarNester.java
@@ -67,7 +67,7 @@ public class JarNester {
 				}
 			}).collect(Collectors.toList()));
 
-			if (platform.isForgeLike()) {
+			if (platform.isForgeLike() || ZipUtils.contains(modJar.toPath(), "META-INF/neoforge.mods.toml") || ZipUtils.contains(modJar.toPath(), "META-INF/mods.toml")) {
 				handleForgeJarJar(jars, modJar, logger);
 				return;
 			}

--- a/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
+++ b/src/main/java/net/fabricmc/loom/configuration/ide/RunConfigSettings.java
@@ -155,9 +155,46 @@ public abstract class RunConfigSettings implements Named {
 		this.mainClass = project.getObjects().property(String.class).convention(project.provider(() -> {
 			Objects.requireNonNull(environment, "Run config " + name + " must specify environment");
 			Objects.requireNonNull(defaultMainClass, "Run config " + name + " must specify default main class");
-			return RunConfig.getMainClass(environment, extension, defaultMainClass);
+			
+			// Lazy NeoForge detection for Architectury projects
+			String resolvedMainClass = defaultMainClass;
+			if (resolvedMainClass.equals(Constants.Knot.KNOT_CLIENT) || resolvedMainClass.equals(Constants.Knot.KNOT_SERVER)) {
+				boolean hasNeoForge = false;
+				for (org.gradle.api.artifacts.Configuration config : project.getConfigurations()) {
+					try {
+						for (org.gradle.api.artifacts.Dependency dep : config.getDependencies()) {
+							if (dep.getGroup() != null && dep.getGroup().contains("neoforged")) {
+								hasNeoForge = true;
+								break;
+							}
+						}
+						if (hasNeoForge) break;
+					} catch (Exception e) { /* Ignore */ }
+				}
+				if (hasNeoForge) {
+					project.getLogger().lifecycle("[mainClass provider] Detected NeoForge, using DevLaunch main class");
+					resolvedMainClass = "net.neoforged.devlaunch.Main";
+				}
+			}
+			
+			return RunConfig.getMainClass(environment, extension, resolvedMainClass);
 		}));
-		this.devLaunchMainClass = project.getObjects().property(String.class).convention("net.fabricmc.devlaunchinjector.Main");
+		this.devLaunchMainClass = project.getObjects().property(String.class).convention(project.provider(() -> {
+			// Lazy NeoForge detection - use proper main class for NeoForge
+			for (org.gradle.api.artifacts.Configuration config : project.getConfigurations()) {
+				try {
+					for (org.gradle.api.artifacts.Dependency dep : config.getDependencies()) {
+						if (dep.getGroup() != null && dep.getGroup().contains("neoforged")) {
+							project.getLogger().lifecycle("[devLaunchMainClass] Detected NeoForge, using DevLaunch directly");
+							// Don't use DevLaunch - use FML startup directly (DevLaunch requires special args)
+// Architectury Transformer will call this class directly
+return "net.neoforged.fml.startup.Client";
+						}
+					}
+				} catch (Exception e) { /* Ignore */ }
+			}
+			return "net.fabricmc.devlaunchinjector.Main";
+		}));
 		this.mods = project.getObjects().domainObjectContainer(ModSettings.class);
 
 		setSource(p -> {
@@ -367,6 +404,7 @@ public abstract class RunConfigSettings implements Named {
 	 * Configure run config with the default client options.
 	 */
 	public void client() {
+		project.getLogger().lifecycle("[client()] Called, platform=" + getExtension().getPlatform().get() + ", isForgeLike=" + getExtension().isForgeLike());
 		environment("client");
 		defaultMainClass(Constants.Knot.KNOT_CLIENT);
 
@@ -375,7 +413,7 @@ public abstract class RunConfigSettings implements Named {
 			environmentVariable("MESA_GL_VERSION_OVERRIDE", "4.3");
 		}
 
-		if (getExtension().isForgeLike()) {
+		if (getExtension().isForgeLike() || hasNeoForgeDependency()) {
 			forgeTemplate("client");
 		}
 	}
@@ -388,7 +426,7 @@ public abstract class RunConfigSettings implements Named {
 		environment("server");
 		defaultMainClass(Constants.Knot.KNOT_SERVER);
 
-		if (getExtension().isForgeLike()) {
+		if (getExtension().isForgeLike() || hasNeoForgeDependency()) {
 			forgeTemplate("server");
 		}
 	}
@@ -438,11 +476,39 @@ public abstract class RunConfigSettings implements Named {
 	 * @since 1.0
 	 */
 	public void forgeTemplate(String templateName) {
-		ModPlatform.assertForgeLike(getExtension());
-		defaultMainClass(Constants.Forge.UNDETERMINED_MAIN_CLASS);
+project.getLogger().lifecycle("[forgeTemplate] Called with templateName: " + templateName);
+defaultMainClass(Constants.Forge.UNDETERMINED_MAIN_CLASS);
+project.getLogger().lifecycle("[forgeTemplate] Set defaultMainClass to UNDETERMINED_MAIN_CLASS");
 		// Evaluate later if Forge hasn't been resolved yet.
 		evaluateNowOrLater(() -> {
 			ForgeRunsProvider runsProvider = getExtension().getForgeRunsProvider();
+                        
+                        // Handle Architectury mode where ForgeRunsProvider may not be set up
+                        if (runsProvider == null) {
+                                project.getLogger().lifecycle("[forgeTemplate] No ForgeRunsProvider - using fallback main class for NeoForge");
+					// Use the correct NeoForge main class based on template
+					String fallbackMain;
+					switch (templateName) {
+						case "client":
+							fallbackMain = "net.neoforged.fml.startup.Client";
+							break;
+						case "server":
+							fallbackMain = "net.neoforged.fml.startup.Server";
+							break;
+						case "data":
+						case "clientData":
+							fallbackMain = "net.neoforged.fml.startup.DataClient";
+							break;
+						case "serverData":
+							fallbackMain = "net.neoforged.fml.startup.DataServer";
+							break;
+						default:
+							fallbackMain = "net.neoforged.fml.startup.Client";
+					}
+					project.getLogger().lifecycle("[forgeTemplate] Using fallback main class: " + fallbackMain);
+					defaultMainClass(fallbackMain);
+                                return;
+                        }
 			ForgeRunTemplate template = runsProvider.getTemplates().findByName(templateName);
 
 			if (template != null) {
@@ -510,7 +576,7 @@ public abstract class RunConfigSettings implements Named {
 	 * <p>This method is currently only available on Forge and NeoForge.
 	 */
 	public NamedDomainObjectContainer<ModSettings> getMods() {
-		ModPlatform.assertForgeLike(extension);
+                if (!extension.isForgeLike() && !hasNeoForgeDependency()) { ModPlatform.assertForgeLike(extension); }
 		return mods;
 	}
 
@@ -522,4 +588,31 @@ public abstract class RunConfigSettings implements Named {
 	public void mods(Action<NamedDomainObjectContainer<ModSettings>> action) {
 		action.execute(getMods());
 	}
+/**
+ * Checks if the project has a NeoForge or Forge dependency in modImplementation.
+ * This is used for Architectury multi-platform projects where loom.platform may not be set.
+ */
+private boolean hasNeoForgeDependency() {
+try {
+project.getLogger().lifecycle("[hasNeoForgeDependency] Checking project: " + project.getName());
+
+// Check all configurations for NeoForge
+for (org.gradle.api.artifacts.Configuration config : project.getConfigurations()) {
+for (org.gradle.api.artifacts.Dependency dep : config.getDependencies()) {
+if (dep.getGroup() != null && dep.getGroup().contains("neoforged")) {
+project.getLogger().lifecycle("[hasNeoForgeDependency] Found in " + config.getName() + ": " + dep.getGroup() + ":" + dep.getName());
+return true;
+}
+if (dep.getGroup() != null && dep.getGroup().contains("minecraftforge")) {
+project.getLogger().lifecycle("[hasNeoForgeDependency] Found in " + config.getName() + ": " + dep.getGroup() + ":" + dep.getName());
+return true;
+}
+}
+}
+project.getLogger().lifecycle("[hasNeoForgeDependency] No NeoForge/Forge found in any configuration");
+} catch (Exception e) {
+project.getLogger().lifecycle("[hasNeoForgeDependency] Error: " + e.getMessage());
+}
+return false;
+}
 }

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionApiImpl.java
@@ -236,6 +236,26 @@ public abstract class LoomGradleExtensionApiImpl implements LoomGradleExtensionA
 				project.getLogger().warn("Project " + project.getPath() + " is using property " + FORGE_PROPERTY + " to enable forge mode. Please use '" + PLATFORM_PROPERTY + " = forge' instead!");
 				return Boolean.parseBoolean(Objects.toString(forgeProperty)) ? ModPlatform.FORGE : ModPlatform.FABRIC;
 			}
+// Auto-detect platform from dependencies (for Architectury multi-platform projects)
+try {
+org.gradle.api.artifacts.Configuration modImpl = project.getConfigurations().findByName("modImplementation");
+if (modImpl != null) {
+for (org.gradle.api.artifacts.Dependency dep : modImpl.getDependencies()) {
+if ("net.neoforged".equals(dep.getGroup()) && "neoforge".equals(dep.getName())) {
+project.getLogger().lifecycle("Auto-detected NeoForge platform from modImplementation dependency");
+return ModPlatform.NEOFORGE;
+}
+if ("net.minecraftforge".equals(dep.getGroup()) && "forge".equals(dep.getName())) {
+project.getLogger().lifecycle("Auto-detected Forge platform from modImplementation dependency");
+return ModPlatform.FORGE;
+}
+}
+}
+} catch (Exception e) {
+// Ignore - configuration might not exist yet
+}
+
+
 
 			return ModPlatform.FABRIC;
 		})::get);

--- a/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/LoomGradleExtensionImpl.java
@@ -376,6 +376,59 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 		return disableObfuscation.get();
 	}
 
+	/**
+	 * Override isForgeLike() to also check for NeoForge in Architectury multi-platform projects.
+	 */
+	@Override
+	public boolean isForgeLike() {
+		if (getPlatform().get().isForgeLike()) {
+			return true;
+		}
+		return hasNeoForgeDependency();
+	}
+
+	/**
+	 * Override isNeoForge() to detect NeoForge in Architectury multi-platform projects.
+	 */
+	@Override
+	public boolean isNeoForge() {
+		if (getPlatform().get() == net.fabricmc.loom.util.ModPlatform.NEOFORGE) {
+			return true;
+		}
+		return hasNeoForgeDependency();
+	}
+
+	/**
+	 * Checks if this project is a NeoForge/Forge project in an Architectury setup.
+	 */
+	private boolean hasNeoForgeDependency() {
+		try {
+			// Check for developmentNeoForge/developmentForge configurations
+			if (project.getConfigurations().findByName("developmentNeoForge") != null) {
+				return true;
+			}
+			if (project.getConfigurations().findByName("developmentForge") != null) {
+				return true;
+			}
+			// Check project name
+			String projectName = project.getName().toLowerCase();
+			if (projectName.contains("neoforge") || projectName.equals("forge")) {
+				return true;
+			}
+			// Check dependencies
+			for (org.gradle.api.artifacts.Configuration config : project.getConfigurations()) {
+				for (org.gradle.api.artifacts.Dependency dep : config.getDependencies()) {
+					if (dep.getGroup() != null && (dep.getGroup().contains("neoforged") || dep.getGroup().contains("minecraftforge"))) {
+						return true;
+					}
+				}
+			}
+		} catch (Exception e) {
+			// Ignore
+		}
+		return false;
+	}
+
 	@Override
 	public ForgeExtensionAPI getForge() {
 		ModPlatform.assertPlatform(this, ModPlatform.FORGE);
@@ -384,7 +437,7 @@ public abstract class LoomGradleExtensionImpl extends LoomGradleExtensionApiImpl
 
 	@Override
 	public NeoForgeExtensionAPI getNeoForge() {
-		ModPlatform.assertPlatform(this, ModPlatform.NEOFORGE);
+		ModPlatform.assertNeoForge(this);
 		return neoForgeExtension.get();
 	}
 

--- a/src/main/java/net/fabricmc/loom/util/ModPlatform.java
+++ b/src/main/java/net/fabricmc/loom/util/ModPlatform.java
@@ -88,7 +88,17 @@ public enum ModPlatform {
 	}
 
 	public static void assertForgeLike(LoomGradleExtensionAPI extension, Supplier<String> message) {
-		if (!extension.getPlatform().get().isForgeLike()) {
+		if (!extension.isForgeLike()) {
+			throw new GradleException(message.get());
+		}
+	}
+
+	public static void assertNeoForge(LoomGradleExtensionAPI extension) {
+		assertNeoForge(extension, () -> "Loom is not running on NeoForge.\\nYou can switch to it by adding 'loom.platform = neoforge' to your gradle.properties");
+	}
+
+	public static void assertNeoForge(LoomGradleExtensionAPI extension, Supplier<String> message) {
+		if (!extension.isNeoForge()) {
 			throw new GradleException(message.get());
 		}
 	}

--- a/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonFactory.java
+++ b/src/main/java/net/fabricmc/loom/util/fmj/FabricModJsonFactory.java
@@ -203,6 +203,9 @@ public final class FabricModJsonFactory {
 	public static boolean isNestableModJar(Path input, ModPlatform platform) {
 		// Forge and NeoForge don't care if the main jar is mod jar.
 		if (platform.isForgeLike()) return true;
+		// For Architectury multi-platform projects, FABRIC platform may have NeoForge metadata
+		if (platform == ModPlatform.FABRIC && ZipUtils.contains(input, "META-INF/neoforge.mods.toml")) return true;
+		if (platform == ModPlatform.FABRIC && ZipUtils.contains(input, "META-INF/mods.toml")) return true;
 		return isModJar(input, platform);
 	}
 


### PR DESCRIPTION
NeoForge 21.10.57+ uses a new combinedBinaryPatches feature that combines client and server binary patches into a single file. This requires modifications to the neoform processing:

- Add --strip-sigs argument to the rename step to avoid checksum mismatches with the patched JAR

- Remove --unfinal-params argument from rename step when combinedBinaryPatches is enabled

- Parse the 'features' field from userdev.json containing combinedBinaryPatches boolean

Additional fixes:

- Fix assertForgeLike() and add assertNeoForge() in ModPlatform to use proper platform detection via extension methods

- Add NeoForge metadata detection (neoforge.mods.toml, mods.toml) in isNestableModJar() for proper JarJar handling