### PR TITLE
Fix genForgePatchedSources with older Forge versions

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/GenerateForgePatchedSourcesTask.java
+++ b/src/main/java/net/fabricmc/loom/task/GenerateForgePatchedSourcesTask.java
@@ -165,8 +165,8 @@ public abstract class GenerateForgePatchedSourcesTask extends AbstractLoomTask {
 		getSasOptions().set(sasOptions);
 
 		getPatchPathInZip().set(getExtension().getForgeUserdevProvider().getConfig().patches());
-		getPatchesOriginalPrefix().set(getExtension().getForgeUserdevProvider().getConfig().patchesOriginalPrefix().orElseThrow());
-		getPatchesModifiedPrefix().set(getExtension().getForgeUserdevProvider().getConfig().patchesModifiedPrefix().orElseThrow());
+		getPatchesOriginalPrefix().set(getExtension().getForgeUserdevProvider().getConfig().patchesOriginalPrefix().orElse("a/"));
+		getPatchesModifiedPrefix().set(getExtension().getForgeUserdevProvider().getConfig().patchesModifiedPrefix().orElse("b/"));
 
 		getSourceRemapperOptions().set(SourceRemapperService.TYPE.create(getProject(), sro -> {
 			sro.getMappings().set(MappingsService.createOptionsWithProjectMappings(


### PR DESCRIPTION
Older Forge versions (e.g. 1.16.2-33.0.61) do not provide the original/modified prefix in their config, resulting in `NoSuchElementException` at configuration time.
They do appear to use the standard `a`/`b` prefix, so we should be fine simply defaulting to those.