### PR TITLE
Fix cloth-config on 1.17.1

### DIFF
--- a/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
+++ b/src/main/java/net/fabricmc/loom/configuration/mods/ArtifactMetadata.java
@@ -100,7 +100,7 @@ public record ArtifactMetadata(boolean isFabricMod, RemapRequirements remapRequi
 					} catch (IllegalArgumentException e) {
 						throw new IllegalStateException("Unknown mixin remap type: " + mixinRemapType);
 					}
-				} else if (mixinConfigs != null && platform == ModPlatform.FORGE && hasRefmaplessMixinConfig(fs, mixinConfigs)) {
+				} else if (mixinConfigs != null && !mixinConfigs.isBlank() && platform == ModPlatform.FORGE && hasRefmaplessMixinConfig(fs, mixinConfigs)) {
 					// On Forge, we support both mixins with and without refmaps.
 					// Check for mixins without them, and if any are found, mark the remap type as static.
 					refmapRemapType = MixinRemapType.STATIC;


### PR DESCRIPTION
cloth-config-forge contains an empty entry `MixinConfigs` in 1.17.1 (see [version 5.3.63](https://maven.architectury.dev/me/shedaniel/cloth/cloth-config-forge/5.3.63/cloth-config-forge-5.3.63.jar)).
This leads to a `FileNotFoundError` in `hasRefmaplessMixinConfig`, which is fixed by this simple check.
I could probably also use `!mixinConfigs.isEmpty()` instead of using `isBlank`, but I feel like this is more safe...

This is a port of #326 and #333 for Loom 1.16.