### PR TITLE
Add new Aw2At API compatible with all jar tasks

### DIFF
--- a/src/main/java/dev/architectury/loom/accesstransformer/Aw2At.java
+++ b/src/main/java/dev/architectury/loom/accesstransformer/Aw2At.java
@@ -36,21 +36,42 @@ import dev.architectury.at.AccessTransform;
 import dev.architectury.at.AccessTransformSet;
 import dev.architectury.at.ModifierChange;
 import org.cadixdev.bombe.type.signature.MethodSignature;
+import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.jvm.tasks.Jar;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import net.fabricmc.classtweaker.api.ClassTweakerReader;
 import net.fabricmc.classtweaker.api.visitor.AccessWidenerVisitor;
 import net.fabricmc.classtweaker.api.visitor.ClassTweakerVisitor;
 import net.fabricmc.loom.LoomGradleExtension;
+import net.fabricmc.loom.api.aw2at.Aw2AtSettings;
+import net.fabricmc.loom.task.RemapJarTask;
 
 /**
  * Converts AW files to AT files.
  */
 public final class Aw2At {
+	public static void addToTask(Project project, TaskProvider<? extends Jar> jarTask, Action<? super Aw2AtSettings> action) {
+		// Create and configure the settings object
+		final Aw2AtSettings settings = project.getObjects().newInstance(Aw2AtSettings.class);
+		action.execute(settings);
+
+		// Add the AW conversion to the task. RemapJarTask simply gets the paths added to its own property,
+		// while the action is added to other jar tasks.
+		jarTask.configure(task -> {
+			if (task instanceof RemapJarTask rjt) {
+				rjt.getAtAccessWideners().addAll(settings.getAccessWideners());
+			} else {
+				Aw2AtAction.addToTask(task, settings.getAccessWideners());
+			}
+		});
+	}
+
 	/**
 	 * Gets all to-be-converted access wideners configured in the Loom extension on Forge.
 	 */

--- a/src/main/java/dev/architectury/loom/accesstransformer/Aw2AtAction.java
+++ b/src/main/java/dev/architectury/loom/accesstransformer/Aw2AtAction.java
@@ -32,14 +32,14 @@ public abstract class Aw2AtAction implements Action<Task> {
 	@Optional
 	public abstract Property<MappingsService.Options> getMappingOptions();
 
-	public static void addToTask(Jar task, Provider<Set<String>> awPaths) {
+	static void addToTask(Jar task, Provider<Set<String>> awPaths) {
 		if (task instanceof RemapJarTask) {
 			throw new IllegalArgumentException("Jar task must not be a RemapJarTask");
 		}
 
 		final Aw2AtAction action = task.getProject().getObjects().newInstance(Aw2AtAction.class);
 		action.getAccessWidenerPaths().set(awPaths);
-		// RemapJarTask already sets up the inputs on its own
+		// RemapJarTask already sets up the inputs on its own, but we have to add them manually to other jar tasks.
 		task.getInputs().property("atAccessWideners", awPaths);
 		task.doLast(action);
 	}

--- a/src/main/java/net/fabricmc/loom/api/ForgeExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/ForgeExtensionAPI.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021-2024 FabricMC
+ * Copyright (c) 2021-2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,12 @@ import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.jvm.tasks.Jar;
 import org.jetbrains.annotations.ApiStatus;
+
+import net.fabricmc.loom.api.aw2at.Aw2AtSettings;
+import net.fabricmc.loom.util.Check;
 
 /**
  * This is the Forge extension API available to build scripts.
@@ -41,6 +46,10 @@ public interface ForgeExtensionAPI {
 	 * If true, {@linkplain LoomGradleExtensionAPI#getAccessWidenerPath() the project access widener file}
 	 * will be remapped to an access transformer file if set.
 	 *
+	 * <p>Note that {@link #convertAccessWideners(TaskProvider, String...)} can be used instead of this
+	 * method for more fine-grained control over which jar task converts the access wideners.
+	 * This method targets the {@code remapJar} task on obfuscated versions and the {@code jar} task on unobfuscated versions.
+	 *
 	 * @return the property
 	 */
 	Property<Boolean> getConvertAccessWideners();
@@ -49,6 +58,10 @@ public interface ForgeExtensionAPI {
 	 * A set of additional access widener files that will be converted to access transformers
 	 * {@linkplain #getConvertAccessWideners() if enabled}. The files are specified as paths in jar files
 	 * (e.g. {@code path/to/my_aw.accesswidener}).
+	 *
+	 * <p>Note that {@link #convertAccessWideners(TaskProvider, String...)} can be used instead of this
+	 * method for more fine-grained control over which jar task converts the access wideners.
+	 * This method targets the {@code remapJar} task on obfuscated versions and the {@code jar} task on unobfuscated versions.
 	 *
 	 * @return the property
 	 */
@@ -71,6 +84,54 @@ public interface ForgeExtensionAPI {
 	 * @param file the file, evaluated as per {@link org.gradle.api.Project#file(Object)}
 	 */
 	void accessTransformer(Object file);
+
+	/**
+	 * Sets up AW → AT conversion for the provided jar task.
+	 *
+	 * <p>The file paths are relative to the mod jar root, corresponding to {@code resources} directories in
+	 * a development environment, <strong>not</strong> the project directory!
+	 * For example, {@code "my_mod.accesswidener"} corresponds to the source file {@code src/main/resources/my_mod.accesswidener}.
+	 *
+	 * <p>The specified files will be converted and removed from the final jar.
+	 *
+	 * <p>In projects with an obfuscated version of Minecraft, this method must target {@code remapJar} or another
+	 * {@link net.fabricmc.loom.task.RemapJarTask} in order for the access transformer to be remapped properly.
+	 *
+	 * <p>When the provided task is a {@link net.fabricmc.loom.task.RemapJarTask}, the AW paths will simply be added
+	 * to the corresponding {@link net.fabricmc.loom.task.RemapJarTask#getAtAccessWideners() atAccessWideners} property.
+	 */
+	@ApiStatus.Experimental
+	void convertAccessWideners(TaskProvider<? extends Jar> jarTask, Action<? super Aw2AtSettings> action);
+
+	/**
+	 * Sets up AW → AT conversion for the provided jar task.
+	 *
+	 * <p>The file paths are relative to the mod jar root, corresponding to {@code resources} directories in
+	 * a development environment, <strong>not</strong> the project directory!
+	 * For example, {@code "my_mod.accesswidener"} corresponds to the source file {@code src/main/resources/my_mod.accesswidener}.
+	 *
+	 * <p>The specified files will be converted and removed from the final jar.
+	 *
+	 * <p>In projects with an obfuscated version of Minecraft, this method must target {@code remapJar} or another
+	 * {@link net.fabricmc.loom.task.RemapJarTask} in order for the access transformer to be remapped properly.
+	 *
+	 * <p>When the provided task is a {@link net.fabricmc.loom.task.RemapJarTask}, the AW paths will simply be added
+	 * to the corresponding {@link net.fabricmc.loom.task.RemapJarTask#getAtAccessWideners() atAccessWideners} property.
+	 *
+	 * <p>Usage example on unobfuscated versions:
+	 * {@snippet : lang=groovy
+	 * loom.forge.convertAccessWideners(tasks.jar, "my_mod.accesswidener")
+	 * }
+	 *
+	 * @param awPaths the paths of the access wideners relative to the mod jar root, cannot be empty
+	 */
+	@ApiStatus.Experimental
+	default void convertAccessWideners(TaskProvider<? extends Jar> jarTask, String... awPaths) {
+		Check.require(awPaths.length >= 1, "At least one access widener path must be provided");
+		convertAccessWideners(jarTask, settings -> {
+			settings.getAccessWideners().addAll(awPaths);
+		});
+	}
 
 	/**
 	 * A set of all mixin configs related to source set resource roots.

--- a/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/LoomGradleExtensionAPI.java
@@ -318,6 +318,28 @@ public interface LoomGradleExtensionAPI {
 	 */
 	FileCollection getNamedMinecraftJars();
 
+	/**
+	 * Nest mod jars from a {@link FileCollection} into the specified jar task.
+	 * This is useful for including locally built mod jars or jars that don't come from Maven.
+	 *
+	 * <p>Important: The jars must already be valid mod jars (containing a fabric.mod.json file).
+	 * Non-mod jars will be rejected.
+	 *
+	 * <p>Example usage:
+	 * {@snippet lang=groovy :
+	 * loom {
+	 *     nestJars(tasks.jar, files('local-mod.jar'))
+	 *     nestJars(tasks.remapJar, tasks.named('buildOtherMod'))
+	 * }
+	 * }
+	 *
+	 * @param jarTask the jar task to nest jars into (can be jar or remapJar)
+	 * @param jars the file collection containing mod jars to nest
+	 * @since 1.14
+	 */
+	@ApiStatus.Experimental
+	void nestJars(TaskProvider<? extends Jar> jarTask, FileCollection jars);
+
 	// ===================
 	//  Architectury Loom
 	// ===================
@@ -388,26 +410,4 @@ public interface LoomGradleExtensionAPI {
 	NeoForgeExtensionAPI getNeoForge();
 
 	void neoForge(Action<NeoForgeExtensionAPI> action);
-
-	/**
-	 * Nest mod jars from a {@link FileCollection} into the specified jar task.
-	 * This is useful for including locally built mod jars or jars that don't come from Maven.
-	 *
-	 * <p>Important: The jars must already be valid mod jars (containing a fabric.mod.json file).
-	 * Non-mod jars will be rejected.
-	 *
-	 * <p>Example usage:
-	 * {@snippet lang=groovy :
-	 * loom {
-	 *     nestJars(tasks.jar, files('local-mod.jar'))
-	 *     nestJars(tasks.remapJar, tasks.named('buildOtherMod'))
-	 * }
-	 * }
-	 *
-	 * @param jarTask the jar task to nest jars into (can be jar or remapJar)
-	 * @param jars the file collection containing mod jars to nest
-	 * @since 1.14
-	 */
-	@ApiStatus.Experimental
-	void nestJars(TaskProvider<? extends Jar> jarTask, FileCollection jars);
 }

--- a/src/main/java/net/fabricmc/loom/api/NeoForgeExtensionAPI.java
+++ b/src/main/java/net/fabricmc/loom/api/NeoForgeExtensionAPI.java
@@ -24,8 +24,14 @@
 
 package net.fabricmc.loom.api;
 
+import org.gradle.api.Action;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.jvm.tasks.Jar;
+import org.jetbrains.annotations.ApiStatus;
+
+import net.fabricmc.loom.api.aw2at.Aw2AtSettings;
+import net.fabricmc.loom.util.Check;
 
 /**
  * This is the NeoForge extension API available to build scripts.
@@ -50,8 +56,7 @@ public interface NeoForgeExtensionAPI {
 	void accessTransformer(Object file);
 
 	/**
-	 * Gets the jar paths to the access wideners or class tweakers that will be converted to ATs for NeoForge runtime.
-	 * If you specify multiple files, they will be merged into one.
+	 * Sets up AW → AT conversion for the provided jar task.
 	 *
 	 * <p>The file paths are relative to the mod jar root, corresponding to {@code resources} directories in
 	 * a development environment, <strong>not</strong> the project directory!
@@ -59,11 +64,42 @@ public interface NeoForgeExtensionAPI {
 	 *
 	 * <p>The specified files will be converted and removed from the final jar.
 	 *
-	 * <p>In projects on Minecraft versions that are obfuscated, this property is simply added to the corresponding
-	 * property in {@link net.fabricmc.loom.task.RemapJarTask}.
+	 * <p>In projects with an obfuscated version of Minecraft, this method must target {@code remapJar} or another
+	 * {@link net.fabricmc.loom.task.RemapJarTask} in order for the access transformer to be remapped properly.
 	 *
-	 * @return the property containing access widener paths in the final jar
-	 * @see net.fabricmc.loom.task.RemapJarTask#getAtAccessWideners()
+	 * <p>When the provided task is a {@link net.fabricmc.loom.task.RemapJarTask}, the AW paths will simply be added
+	 * to the corresponding {@link net.fabricmc.loom.task.RemapJarTask#getAtAccessWideners() atAccessWideners} property.
 	 */
-	SetProperty<String> getAtAccessWideners();
+	@ApiStatus.Experimental
+	void convertAccessWideners(TaskProvider<? extends Jar> jarTask, Action<? super Aw2AtSettings> action);
+
+	/**
+	 * Sets up AW → AT conversion for the provided jar task.
+	 *
+	 * <p>The file paths are relative to the mod jar root, corresponding to {@code resources} directories in
+	 * a development environment, <strong>not</strong> the project directory!
+	 * For example, {@code "my_mod.accesswidener"} corresponds to the source file {@code src/main/resources/my_mod.accesswidener}.
+	 *
+	 * <p>The specified files will be converted and removed from the final jar.
+	 *
+	 * <p>In projects with an obfuscated version of Minecraft, this method must target {@code remapJar} or another
+	 * {@link net.fabricmc.loom.task.RemapJarTask} in order for the access transformer to be remapped properly.
+	 *
+	 * <p>When the provided task is a {@link net.fabricmc.loom.task.RemapJarTask}, the AW paths will simply be added
+	 * to the corresponding {@link net.fabricmc.loom.task.RemapJarTask#getAtAccessWideners() atAccessWideners} property.
+	 *
+	 * <p>Usage example:
+	 * {@snippet : lang=kotlin
+	 * loom.neoForge.convertAccessWideners(tasks.jar, "my_mod.accesswidener")
+	 * }
+	 *
+	 * @param awPaths the paths of the access wideners relative to the mod jar root, cannot be empty
+	 */
+	@ApiStatus.Experimental
+	default void convertAccessWideners(TaskProvider<? extends Jar> jarTask, String... awPaths) {
+		Check.require(awPaths.length >= 1, "At least one access widener path must be provided");
+		convertAccessWideners(jarTask, settings -> {
+			settings.getAccessWideners().addAll(awPaths);
+		});
+	}
 }

--- a/src/main/java/net/fabricmc/loom/api/aw2at/Aw2AtSettings.java
+++ b/src/main/java/net/fabricmc/loom/api/aw2at/Aw2AtSettings.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2023-2026 FabricMC
+ * Copyright (c) 2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,42 +22,24 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.extension;
+package net.fabricmc.loom.api.aw2at;
 
-import javax.inject.Inject;
+import org.gradle.api.provider.SetProperty;
+import org.jetbrains.annotations.ApiStatus;
 
-import dev.architectury.loom.accesstransformer.Aw2At;
-import org.gradle.api.Action;
-import org.gradle.api.Project;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.jvm.tasks.Jar;
-
-import net.fabricmc.loom.api.NeoForgeExtensionAPI;
-import net.fabricmc.loom.api.aw2at.Aw2AtSettings;
-
-public abstract class NeoForgeExtensionImpl implements NeoForgeExtensionAPI {
-	private final Project project;
-	private final ConfigurableFileCollection accessTransformers;
-
-	@Inject
-	public NeoForgeExtensionImpl(Project project) {
-		accessTransformers = project.getObjects().fileCollection();
-		this.project = project;
-	}
-
-	@Override
-	public ConfigurableFileCollection getAccessTransformers() {
-		return accessTransformers;
-	}
-
-	@Override
-	public void accessTransformer(Object file) {
-		accessTransformers.from(file);
-	}
-
-	@Override
-	public void convertAccessWideners(TaskProvider<? extends Jar> jarTask, Action<? super Aw2AtSettings> action) {
-		Aw2At.addToTask(project, jarTask, action);
-	}
+@ApiStatus.Experimental
+public interface Aw2AtSettings {
+	/**
+	 * Gets the jar paths to the access wideners or class tweakers that will be converted to ATs for Forge or NeoForge runtime.
+	 * If you specify multiple files, they will be merged into one.
+	 *
+	 * <p>The file paths are relative to the mod jar root, corresponding to {@code resources} directories in
+	 * a development environment, <strong>not</strong> the project directory!
+	 * For example, {@code "my_mod.accesswidener"} corresponds to the source file {@code src/main/resources/my_mod.accesswidener}.
+	 *
+	 * <p>The specified files will be converted and removed from the final jar.
+	 *
+	 * @return the property containing access widener paths in the final jar
+	 */
+	SetProperty<String> getAccessWideners();
 }

--- a/src/main/java/net/fabricmc/loom/api/aw2at/package-info.java
+++ b/src/main/java/net/fabricmc/loom/api/aw2at/package-info.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2023-2026 FabricMC
+ * Copyright (c) 2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,42 +22,7 @@
  * SOFTWARE.
  */
 
-package net.fabricmc.loom.extension;
+@NullMarked
+package net.fabricmc.loom.api.aw2at;
 
-import javax.inject.Inject;
-
-import dev.architectury.loom.accesstransformer.Aw2At;
-import org.gradle.api.Action;
-import org.gradle.api.Project;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.tasks.TaskProvider;
-import org.gradle.jvm.tasks.Jar;
-
-import net.fabricmc.loom.api.NeoForgeExtensionAPI;
-import net.fabricmc.loom.api.aw2at.Aw2AtSettings;
-
-public abstract class NeoForgeExtensionImpl implements NeoForgeExtensionAPI {
-	private final Project project;
-	private final ConfigurableFileCollection accessTransformers;
-
-	@Inject
-	public NeoForgeExtensionImpl(Project project) {
-		accessTransformers = project.getObjects().fileCollection();
-		this.project = project;
-	}
-
-	@Override
-	public ConfigurableFileCollection getAccessTransformers() {
-		return accessTransformers;
-	}
-
-	@Override
-	public void accessTransformer(Object file) {
-		accessTransformers.from(file);
-	}
-
-	@Override
-	public void convertAccessWideners(TaskProvider<? extends Jar> jarTask, Action<? super Aw2AtSettings> action) {
-		Aw2At.addToTask(project, jarTask, action);
-	}
-}
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/fabricmc/loom/extension/ForgeExtensionImpl.java
+++ b/src/main/java/net/fabricmc/loom/extension/ForgeExtensionImpl.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021-2023 FabricMC
+ * Copyright (c) 2021-2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,17 +31,22 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import dev.architectury.loom.accesstransformer.Aw2At;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.jvm.tasks.Jar;
 
 import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.api.ForgeExtensionAPI;
+import net.fabricmc.loom.api.aw2at.Aw2AtSettings;
 import net.fabricmc.loom.configuration.ide.RunConfigSettings;
 
 public class ForgeExtensionImpl implements ForgeExtensionAPI {
+	private final Project project;
 	private final LoomGradleExtension extension;
 	private final Property<Boolean> convertAccessWideners;
 	private final SetProperty<String> extraAccessWideners;
@@ -53,6 +58,7 @@ public class ForgeExtensionImpl implements ForgeExtensionAPI {
 
 	@Inject
 	public ForgeExtensionImpl(Project project, LoomGradleExtension extension) {
+		this.project = project;
 		this.extension = extension;
 		convertAccessWideners = project.getObjects().property(Boolean.class).convention(false);
 		extraAccessWideners = project.getObjects().setProperty(String.class).empty();
@@ -80,6 +86,11 @@ public class ForgeExtensionImpl implements ForgeExtensionAPI {
 	@Override
 	public void accessTransformer(Object file) {
 		accessTransformers.from(file);
+	}
+
+	@Override
+	public void convertAccessWideners(TaskProvider<? extends Jar> jarTask, Action<? super Aw2AtSettings> action) {
+		Aw2At.addToTask(project, jarTask, action);
 	}
 
 	@Override

--- a/src/main/java/net/fabricmc/loom/task/NonRemappedJarTaskConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/task/NonRemappedJarTaskConfiguration.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 
 import dev.architectury.loom.accesstransformer.Aw2At;
-import dev.architectury.loom.accesstransformer.Aw2AtAction;
 import dev.architectury.loom.extensions.ModBuildExtensions;
 import dev.architectury.loom.util.PropertyUtil;
 import org.gradle.api.Project;
@@ -80,19 +79,19 @@ public class NonRemappedJarTaskConfiguration {
 			));
 
 			task.usesService(manifestServiceProvider);
-
-			if (extension.isForge()) {
-				if (PropertyUtil.getAndFinalize(extension.getForge().getConvertAccessWideners())) {
-					Aw2AtAction.addToTask(task, Aw2At.getForgeAtAccessWideners(project));
-				}
-
-				ModBuildExtensions.addMixinConfigsToDefaultJarManifest(project);
-			} else if (extension.isNeoForge()) {
-				Aw2AtAction.addToTask(task, extension.getNeoForge().getAtAccessWideners());
-			}
 		});
 
 		extension.getUnmappedModCollection().from(project.getTasks().getByName(JavaPlugin.JAR_TASK_NAME));
+
+		if (extension.isForge()) {
+			if (PropertyUtil.getAndFinalize(extension.getForge().getConvertAccessWideners())) {
+				extension.getForge().convertAccessWideners(project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class), settings -> {
+					settings.getAccessWideners().addAll(Aw2At.getForgeAtAccessWideners(project));
+				});
+			}
+
+			ModBuildExtensions.addMixinConfigsToDefaultJarManifest(project);
+		}
 	}
 
 	private List<String> getClientOnlyEntries() {

--- a/src/main/java/net/fabricmc/loom/task/RemapTaskConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/task/RemapTaskConfiguration.java
@@ -121,10 +121,6 @@ public abstract class RemapTaskConfiguration implements Runnable {
 				}
 
 				ModBuildExtensions.addMixinConfigsToDefaultJarManifest(p);
-			} else if (extension.isNeoForge()) {
-				getTasks().named(REMAP_JAR_TASK_NAME, RemapJarTask.class, task -> {
-					task.getAtAccessWideners().addAll(extension.getNeoForge().getAtAccessWideners());
-				});
 			}
 		});
 

--- a/src/test/groovy/net/fabricmc/loom/test/integration/forge/Aw2AtTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/forge/Aw2AtTest.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2021-2023 FabricMC
+ * Copyright (c) 2021-2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,15 +29,17 @@ import spock.lang.Unroll
 
 import net.fabricmc.loom.test.util.GradleProjectTestTrait
 
-import static net.fabricmc.loom.test.LoomTestConstants.*
+import static net.fabricmc.loom.test.LoomTestConstants.DEFAULT_GRADLE
+import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class Aw2AtTest extends Specification implements GradleProjectTestTrait {
 	@Unroll
-	def "build (gradle #version)"() {
+	def "build (#apiVariant)"() {
 		// 1.17+ uses a new srg naming pattern
 		setup:
-		def gradle = gradleProject(project: "forge/aw2At", version: version)
+		def gradle = gradleProject(project: "forge/aw2At", version: DEFAULT_GRADLE)
+		gradle.buildGradle.text = gradle.buildGradle.text.replace('AW2AT_CODE', code)
 
 		when:
 		def result = gradle.run(task: "build")
@@ -47,7 +49,9 @@ class Aw2AtTest extends Specification implements GradleProjectTestTrait {
 		gradle.getOutputZipEntry("fabric-example-mod-1.0.0.jar", "META-INF/accesstransformer.cfg") == expected(gradle).replaceAll('\r', '')
 
 		where:
-		version << STANDARD_TEST_VERSIONS
+		apiVariant    | code
+		'legacy' | 'convertAccessWideners = true'
+		'new' | 'convertAccessWideners(tasks.named("remapJar"), "my.accesswidener")'
 	}
 
 	@Unroll

--- a/src/test/groovy/net/fabricmc/loom/test/integration/forge/Aw2AtTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/forge/Aw2AtTest.groovy
@@ -49,9 +49,9 @@ class Aw2AtTest extends Specification implements GradleProjectTestTrait {
 		gradle.getOutputZipEntry("fabric-example-mod-1.0.0.jar", "META-INF/accesstransformer.cfg") == expected(gradle).replaceAll('\r', '')
 
 		where:
-		apiVariant    | code
-		'legacy' | 'convertAccessWideners = true'
-		'new' | 'convertAccessWideners(tasks.named("remapJar"), "my.accesswidener")'
+		apiVariant | code
+		'legacy'   | 'convertAccessWideners = true'
+		'new'      | 'convertAccessWideners(tasks.named("remapJar"), "my.accesswidener")'
 	}
 
 	@Unroll

--- a/src/test/resources/projects/forge/aw2At/build.gradle
+++ b/src/test/resources/projects/forge/aw2At/build.gradle
@@ -22,7 +22,7 @@ loom {
 	accessWidenerPath = file('src/main/resources/my.accesswidener')
 
 	forge {
-		convertAccessWideners = true
+		AW2AT_CODE
 	}
 }
 

--- a/src/test/resources/projects/neoforge/261/build.gradle
+++ b/src/test/resources/projects/neoforge/261/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 loom {
 	neoForge {
-		atAccessWideners.addAll('test.accesswidener', 'test2.classtweaker')
+		convertAccessWideners(tasks.named('jar'), 'test.accesswidener', 'test2.classtweaker')
 	}
 }
 


### PR DESCRIPTION
This new API works with any Jar task, although it must be a RemapJarTask on obfuscated versions to handle the remapping. The old API that was added in #339 has been removed accordingly, which is not a breaking change as the version was never released.

Code examples:
```gradle
// Unobf, regular jar
loom.neoForge.convertAccessWideners(tasks.named('jar'), 'my_mod.accesswidener')

// Unobf, shadow jar
loom.neoForge.convertAccessWideners(tasks.named('shadowJar'), 'my_mod.accesswidener')

// Obf, remapped jar
loom.forge.convertAccessWideners(tasks.named('remapJar'), 'my_mod.classtweaker')
```