### PR TITLE
Fix genSources platform mappings

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
+++ b/src/main/java/net/fabricmc/loom/task/service/SourceMappingsService.java
@@ -129,7 +129,7 @@ public class SourceMappingsService extends Service<SourceMappingsService.Options
 		try {
 			Files.createDirectories(dir);
 			Files.deleteIfExists(path);
-			final Path inputMappings = disableObf ? emptyMappingsPath : extension.getMappingConfiguration().tinyMappings;
+			final Path inputMappings = disableObf ? emptyMappingsPath : extension.getPlatformMappingFile();
 			createMappings(project, jarProcessor, inputMappings, path);
 		} catch (IOException e) {
 			throw new UncheckedIOException("Failed to create source mappings", e);


### PR DESCRIPTION
The source mappings generated for `genSources` should use the platform mapping file instead of the raw tiny mappings file.

On Forge with Mojang mappings, the platform mapping file includes the SRG mappings expected by the jar processor. Using the raw tiny mappings file can pass `intermediary` as the source namespace instead, causing `GenerateSourcesTask` creation to fail with `Mapping tree must have srg src mappings not intermediary`.

Fixes #334.

Verified locally against the reported Gradle 9 / Forge setup.