### PR TITLE
Fix access widener conversion not being reproducible

### DIFF
--- a/src/main/java/dev/architectury/loom/extensions/ModBuildExtensions.java
+++ b/src/main/java/dev/architectury/loom/extensions/ModBuildExtensions.java
@@ -3,6 +3,7 @@ package dev.architectury.loom.extensions;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +33,7 @@ import net.fabricmc.loom.LoomGradleExtension;
 import net.fabricmc.loom.task.service.MappingsService;
 import net.fabricmc.loom.util.Constants;
 import net.fabricmc.loom.util.FileSystemUtil;
+import net.fabricmc.loom.util.ZipReprocessorUtil;
 import net.fabricmc.loom.util.service.ServiceFactory;
 
 public final class ModBuildExtensions {
@@ -96,17 +98,22 @@ public final class ModBuildExtensions {
 
 				Files.delete(awPath);
 			}
-
-			// Remap the AT if mappings are provided
-			if (mappingOptions.isPresent()) {
-				MappingsService service = serviceFactory.get(mappingOptions);
-				at = at.remap(service.getMemoryMappingTree(), service.getFrom(), service.getTo());
-			}
-
-			// Write out the merged and possibly remapped AT
-			try (Writer writer = new LfWriter(Files.newBufferedWriter(atPath))) {
-				AccessTransformFormats.FML.write(writer, at);
-			}
 		}
+
+		// Remap the AT if mappings are provided
+		if (mappingOptions.isPresent()) {
+			MappingsService service = serviceFactory.get(mappingOptions);
+			at = at.remap(service.getMemoryMappingTree(), service.getFrom(), service.getTo());
+		}
+
+		// Write out the merged and possibly remapped AT
+		var stringWriter = new StringWriter();
+
+		try (Writer writer = new LfWriter(stringWriter)) {
+			AccessTransformFormats.FML.write(writer, at);
+		}
+
+		byte[] atBytes = stringWriter.toString().getBytes(StandardCharsets.UTF_8);
+		ZipReprocessorUtil.appendZipEntry(outputFile, Constants.Forge.ACCESS_TRANSFORMER_PATH, atBytes);
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/forge/Aw2AtTest.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/forge/Aw2AtTest.groovy
@@ -28,6 +28,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import net.fabricmc.loom.util.Checksum
 
 import static net.fabricmc.loom.test.LoomTestConstants.DEFAULT_GRADLE
 import static net.fabricmc.loom.test.LoomTestConstants.STANDARD_TEST_VERSIONS
@@ -47,6 +48,7 @@ class Aw2AtTest extends Specification implements GradleProjectTestTrait {
 		then:
 		result.task(":build").outcome == SUCCESS
 		gradle.getOutputZipEntry("fabric-example-mod-1.0.0.jar", "META-INF/accesstransformer.cfg") == expected(gradle).replaceAll('\r', '')
+		hash(gradle.getOutputFile("fabric-example-mod-1.0.0.jar")) == '2c35db7629e0bda5e79001615751e99c'
 
 		where:
 		apiVariant | code
@@ -66,6 +68,7 @@ class Aw2AtTest extends Specification implements GradleProjectTestTrait {
 		then:
 		result.task(":build").outcome == SUCCESS
 		gradle.getOutputZipEntry("fabric-example-mod-1.0.0.jar", "META-INF/accesstransformer.cfg") == expected(gradle).replaceAll('\r', '')
+		hash(gradle.getOutputFile("fabric-example-mod-1.0.0.jar")) == '714f7823923fc90d06bb601f32955458'
 
 		where:
 		version << STANDARD_TEST_VERSIONS
@@ -83,6 +86,7 @@ class Aw2AtTest extends Specification implements GradleProjectTestTrait {
 		then:
 		result.task(":build").outcome == SUCCESS
 		gradle.getOutputZipEntry("fabric-example-mod-1.0.0.jar", "META-INF/accesstransformer.cfg") == expected(gradle).replaceAll('\r', '')
+		hash(gradle.getOutputFile("fabric-example-mod-1.0.0.jar")) == '714f7823923fc90d06bb601f32955458'
 
 		where:
 		version << STANDARD_TEST_VERSIONS
@@ -90,5 +94,9 @@ class Aw2AtTest extends Specification implements GradleProjectTestTrait {
 
 	private static String expected(GradleProject gradle) {
 		return new File(gradle.projectDir, "expected.accesstransformer.cfg").text
+	}
+
+	private static String hash(File file) {
+		return Checksum.of(file).md5().hex()
 	}
 }

--- a/src/test/groovy/net/fabricmc/loom/test/integration/neoforge/NeoForge261Test.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/neoforge/NeoForge261Test.groovy
@@ -1,7 +1,7 @@
 /*
  * This file is part of fabric-loom, licensed under the MIT License (MIT).
  *
- * Copyright (c) 2025 FabricMC
+ * Copyright (c) 2026 FabricMC
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import net.fabricmc.loom.util.Checksum
 
 import static net.fabricmc.loom.test.LoomTestConstants.DEFAULT_GRADLE
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -52,6 +53,7 @@ class NeoForge261Test extends Specification implements GradleProjectTestTrait {
 		then:
 		result.task(":build").outcome == SUCCESS
 		gradle.getOutputZipEntry("fabric-example-mod-1.0.0.jar", "META-INF/accesstransformer.cfg") == expectedAt
+		Checksum.of(gradle.getOutputFile("fabric-example-mod-1.0.0.jar")).md5().hex() == 'f583b1d0fc1e054568c799d7c3959d73'
 
 		where:
 		mcVersion            | neoforgeVersion


### PR DESCRIPTION
The issue only affects builds with no remapping, but the same `ZipReprocessorUtil.appendZipEntry` code path should be cheap enough to use for them all (if not, it can be changed to `ZipUtils.add` in the future).