### PR TITLE
Fix unobfuscated Forge builds (wrong mcp step, missing manifest)

### DIFF
--- a/src/main/java/dev/architectury/loom/forge/minecraft/MinecraftPatchedProvider.java
+++ b/src/main/java/dev/architectury/loom/forge/minecraft/MinecraftPatchedProvider.java
@@ -285,6 +285,7 @@ public class MinecraftPatchedProvider {
 		try (var tempFiles = new TempFiles(); var serviceFactory = new ScopedServiceFactory()) {
 			McpExecutorBuilder builder = createMcpExecutor(tempFiles.directory("loom-mcp"));
 			builder.enqueue("preProcessJar");
+			builder.enqueue("patch");
 			McpExecutor executor = serviceFactory.get(builder.build());
 			Path output = executor.execute();
 			Files.copy(output, minecraftIntermediateJar, StandardCopyOption.REPLACE_EXISTING);

--- a/src/main/java/dev/architectury/loom/forge/minecraft/MinecraftPatchedProvider.java
+++ b/src/main/java/dev/architectury/loom/forge/minecraft/MinecraftPatchedProvider.java
@@ -257,6 +257,11 @@ public class MinecraftPatchedProvider {
 		Files.deleteIfExists(mcOutput);
 		Files.copy(minecraftPatchedIntermediateAtJar, mcOutput);
 
+		// No manifest available to reuse here (mergetool's output has none, Forge's own jar is signed).
+		try (FileSystemUtil.Delegate fs = FileSystemUtil.getJarFileSystem(mcOutput, false)) {
+			createEmptyJarManifest(fs.getPath("META-INF", "MANIFEST.MF"));
+		}
+
 		copyUserdevFiles(forgeUserdevJar, mcOutput);
 		applyLoomPatchVersion(mcOutput);
 	}
@@ -285,7 +290,7 @@ public class MinecraftPatchedProvider {
 		try (var tempFiles = new TempFiles(); var serviceFactory = new ScopedServiceFactory()) {
 			McpExecutorBuilder builder = createMcpExecutor(tempFiles.directory("loom-mcp"));
 			builder.enqueue("preProcessJar");
-			builder.enqueue("patch");
+			builder.enqueue("merge");
 			McpExecutor executor = serviceFactory.get(builder.build());
 			Path output = executor.execute();
 			Files.copy(output, minecraftIntermediateJar, StandardCopyOption.REPLACE_EXISTING);

--- a/src/main/java/dev/architectury/loom/forge/minecraft/MinecraftPatchedProvider.java
+++ b/src/main/java/dev/architectury/loom/forge/minecraft/MinecraftPatchedProvider.java
@@ -289,8 +289,7 @@ public class MinecraftPatchedProvider {
 	private void createUnobfuscatedPrePatchJar() throws IOException {
 		try (var tempFiles = new TempFiles(); var serviceFactory = new ScopedServiceFactory()) {
 			McpExecutorBuilder builder = createMcpExecutor(tempFiles.directory("loom-mcp"));
-			builder.enqueue("preProcessJar");
-			builder.enqueue("merge");
+			builder.enqueue(getExtension().isNeoForge() ? "preProcessJar" : "merge");
 			McpExecutor executor = serviceFactory.get(builder.build());
 			Path output = executor.execute();
 			Files.copy(output, minecraftIntermediateJar, StandardCopyOption.REPLACE_EXISTING);

--- a/src/test/groovy/net/fabricmc/loom/test/integration/forge/Forge261Test.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/forge/Forge261Test.groovy
@@ -1,0 +1,58 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration.forge
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+
+import static net.fabricmc.loom.test.LoomTestConstants.DEFAULT_GRADLE
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class Forge261Test extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "build #mcVersion #forgeVersion"() {
+		if (Integer.valueOf(System.getProperty("java.version").split("\\.")[0]) < 25) {
+			println("This test requires Java 25. Currently you have Java ${System.getProperty("java.version")}.")
+			return
+		}
+
+		setup:
+		def gradle = gradleProject(project: "forge/261", version: DEFAULT_GRADLE)
+		gradle.buildGradle.text = gradle.buildGradle.text.replace('@MCVERSION@', mcVersion)
+				.replace('@FORGEVERSION@', forgeVersion)
+
+		when:
+		def result = gradle.run(task: "build")
+
+		then:
+		result.task(":build").outcome == SUCCESS
+
+		where:
+		mcVersion | forgeVersion
+		'26.1'    | '62.0.9'
+	}
+}

--- a/src/test/groovy/net/fabricmc/loom/test/integration/forge/Forge262Test.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/forge/Forge262Test.groovy
@@ -1,0 +1,58 @@
+/*
+ * This file is part of fabric-loom, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2026 FabricMC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package net.fabricmc.loom.test.integration.forge
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import net.fabricmc.loom.test.util.GradleProjectTestTrait
+
+import static net.fabricmc.loom.test.LoomTestConstants.DEFAULT_GRADLE
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class Forge262Test extends Specification implements GradleProjectTestTrait {
+	@Unroll
+	def "build #mcVersion #forgeVersion"() {
+		if (Integer.valueOf(System.getProperty("java.version").split("\\.")[0]) < 25) {
+			println("This test requires Java 25. Currently you have Java ${System.getProperty("java.version")}.")
+			return
+		}
+
+		setup:
+		def gradle = gradleProject(project: "forge/262", version: DEFAULT_GRADLE)
+		gradle.buildGradle.text = gradle.buildGradle.text.replace('@MCVERSION@', mcVersion)
+				.replace('@FORGEVERSION@', forgeVersion)
+
+		when:
+		def result = gradle.run(task: "build")
+
+		then:
+		result.task(":build").outcome == SUCCESS
+
+		where:
+		mcVersion | forgeVersion
+		'26.2'    | '65.0.0'
+	}
+}

--- a/src/test/resources/projects/forge/261/build.gradle
+++ b/src/test/resources/projects/forge/261/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+	id 'dev.architectury.loom-no-remap'
+	id 'maven-publish'
+}
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
+}
+
+base {
+	archivesName = project.archives_base_name
+}
+
+version = project.mod_version
+group = project.maven_group
+
+def mcVersion = "@MCVERSION@"
+def forgeVersion = "@FORGEVERSION@"
+
+dependencies {
+	minecraft "com.mojang:minecraft:$mcVersion"
+	forge "net.minecraftforge:forge:$mcVersion-$forgeVersion"
+}
+
+tasks.withType(JavaCompile).configureEach {
+	it.options.release = 21
+}
+
+java {
+	withSourcesJar()
+}
+
+jar {
+	from("LICENSE") {
+		rename { "${it}_${project.archivesBaseName}"}
+	}
+}
+
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			from components.java
+		}
+	}
+}

--- a/src/test/resources/projects/forge/261/gradle.properties
+++ b/src/test/resources/projects/forge/261/gradle.properties
@@ -1,0 +1,10 @@
+# Done to increase the memory available to gradle.
+org.gradle.jvmargs=-Xmx1G
+
+# Mod Properties
+mod_version = 1.0.0
+maven_group = com.example
+archives_base_name = fabric-example-mod
+
+# Dependencies
+loom.platform = forge

--- a/src/test/resources/projects/forge/261/settings.gradle
+++ b/src/test/resources/projects/forge/261/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "fabric-example-mod"

--- a/src/test/resources/projects/forge/262/build.gradle
+++ b/src/test/resources/projects/forge/262/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+	id 'dev.architectury.loom-no-remap'
+	id 'maven-publish'
+}
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
+}
+
+base {
+	archivesName = project.archives_base_name
+}
+
+version = project.mod_version
+group = project.maven_group
+
+def mcVersion = "@MCVERSION@"
+def forgeVersion = "@FORGEVERSION@"
+
+dependencies {
+	minecraft "com.mojang:minecraft:$mcVersion"
+	forge "net.minecraftforge:forge:$mcVersion-$forgeVersion"
+}
+
+tasks.withType(JavaCompile).configureEach {
+	it.options.release = 21
+}
+
+java {
+	withSourcesJar()
+}
+
+jar {
+	from("LICENSE") {
+		rename { "${it}_${project.archivesBaseName}"}
+	}
+}
+
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			from components.java
+		}
+	}
+}

--- a/src/test/resources/projects/forge/262/gradle.properties
+++ b/src/test/resources/projects/forge/262/gradle.properties
@@ -1,0 +1,10 @@
+# Done to increase the memory available to gradle.
+org.gradle.jvmargs=-Xmx1G
+
+# Mod Properties
+mod_version = 1.0.0
+maven_group = com.example
+archives_base_name = fabric-example-mod
+
+# Dependencies
+loom.platform = forge

--- a/src/test/resources/projects/forge/262/settings.gradle
+++ b/src/test/resources/projects/forge/262/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "fabric-example-mod"


### PR DESCRIPTION
finished up the unobfuscated Forge path a bit further (still rough since 9e04ddb5)

- createUnobfuscatedPrePatchJar() now also enqueues "merge" for Forge (preProcessJar alone resolved to 0 MCP steps there).
- mergeUnobfuscatedPatchedJar() now writes an empty manifest instead of leaving it missing
- Added Forge261Test/Forge262Test since there were 0 tests for unobfuscated Forge