### PR TITLE
mixinConfigs and convertAccessWideners not applied when using loom-no-remap

### DIFF
--- a/src/main/java/net/fabricmc/loom/task/NonRemappedJarTaskConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/task/NonRemappedJarTaskConfiguration.java
@@ -83,15 +83,17 @@ public class NonRemappedJarTaskConfiguration {
 
 		extension.getUnmappedModCollection().from(project.getTasks().named(JavaPlugin.JAR_TASK_NAME));
 
-		if (extension.isForge()) {
-			if (PropertyUtil.getAndFinalize(extension.getForge().getConvertAccessWideners())) {
-				extension.getForge().convertAccessWideners(project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class), settings -> {
-					settings.getAccessWideners().addAll(Aw2At.getForgeAtAccessWideners(project));
-				});
-			}
+		project.afterEvaluate(p -> {
+			if (extension.isForge()) {
+				if (PropertyUtil.getAndFinalize(extension.getForge().getConvertAccessWideners())) {
+					extension.getForge().convertAccessWideners(project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class), settings -> {
+						settings.getAccessWideners().addAll(Aw2At.getForgeAtAccessWideners(project));
+					});
+				}
 
-			ModBuildExtensions.addMixinConfigsToDefaultJarManifest(project);
-		}
+				ModBuildExtensions.addMixinConfigsToDefaultJarManifest(project);
+			}
+		});
 	}
 
 	private List<String> getClientOnlyEntries() {

--- a/src/main/java/net/fabricmc/loom/task/NonRemappedJarTaskConfiguration.java
+++ b/src/main/java/net/fabricmc/loom/task/NonRemappedJarTaskConfiguration.java
@@ -44,6 +44,7 @@ import net.fabricmc.loom.configuration.providers.minecraft.MinecraftSourceSets;
 import net.fabricmc.loom.task.service.ClientEntriesService;
 import net.fabricmc.loom.task.service.JarManifestService;
 import net.fabricmc.loom.util.Constants;
+import net.fabricmc.loom.util.gradle.GradleUtils;
 import net.fabricmc.loom.util.gradle.SourceSetHelper;
 import net.fabricmc.loom.util.service.ScopedServiceFactory;
 
@@ -83,7 +84,7 @@ public class NonRemappedJarTaskConfiguration {
 
 		extension.getUnmappedModCollection().from(project.getTasks().named(JavaPlugin.JAR_TASK_NAME));
 
-		project.afterEvaluate(p -> {
+		GradleUtils.afterSuccessfulEvaluation(project, () -> {
 			if (extension.isForge()) {
 				if (PropertyUtil.getAndFinalize(extension.getForge().getConvertAccessWideners())) {
 					extension.getForge().convertAccessWideners(project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class), settings -> {

--- a/src/test/groovy/net/fabricmc/loom/test/integration/forge/Forge261Test.groovy
+++ b/src/test/groovy/net/fabricmc/loom/test/integration/forge/Forge261Test.groovy
@@ -24,10 +24,14 @@
 
 package net.fabricmc.loom.test.integration.forge
 
+import java.util.jar.Manifest
+
 import spock.lang.Specification
 import spock.lang.Unroll
 
 import net.fabricmc.loom.test.util.GradleProjectTestTrait
+import net.fabricmc.loom.util.Constants
+import net.fabricmc.loom.util.ZipUtils
 
 import static net.fabricmc.loom.test.LoomTestConstants.DEFAULT_GRADLE
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
@@ -50,6 +54,10 @@ class Forge261Test extends Specification implements GradleProjectTestTrait {
 
 		then:
 		result.task(":build").outcome == SUCCESS
+
+		def main = gradle.getOutputFile("fabric-example-mod-1.0.0.jar").toPath()
+		def manifest = new Manifest(new ByteArrayInputStream(ZipUtils.unpack(main, "META-INF/MANIFEST.MF")))
+		manifest.getMainAttributes().getValue(Constants.Forge.MIXIN_CONFIGS_MANIFEST_KEY) == "test.mixins.json"
 
 		where:
 		mcVersion | forgeVersion

--- a/src/test/resources/projects/forge/261/build.gradle
+++ b/src/test/resources/projects/forge/261/build.gradle
@@ -18,6 +18,12 @@ group = project.maven_group
 def mcVersion = "@MCVERSION@"
 def forgeVersion = "@FORGEVERSION@"
 
+loom {
+	forge {
+		mixinConfigs "test.mixins.json"
+	}
+}
+
 dependencies {
 	minecraft "com.mojang:minecraft:$mcVersion"
 	forge "net.minecraftforge:forge:$mcVersion-$forgeVersion"

--- a/src/test/resources/projects/forge/261/src/main/resources/test.mixins.json
+++ b/src/test/resources/projects/forge/261/src/main/resources/test.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.example.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
This PR makes the no-remap path use the same `afterEvaluate` behavior as the remap path and adds a regression test to Forge261Test.

Caused by 382bdc28, which made loom.forge.mixinConfigs(...) and convertAccessWideners get finalized too early under dev.architectury.loom-no-remap. As a result, the built jar never received a MixinConfigs manifest entry and Forge loaded no mixin configs at runtime.